### PR TITLE
fix(PROD-7888): Map null and un-handled scenario run statuses to a new 'Unknown' Scenario state

### DIFF
--- a/scenario/src/main/openapi/scenarios.yaml
+++ b/scenario/src/main/openapi/scenarios.yaml
@@ -480,7 +480,17 @@ components:
           type: string
           readOnly: true
           description: the Scenario state
-          enum: ["Created","Running","Successful","Failed"]
+          enum:
+            - Created
+            - Running
+            - Successful
+            - Failed
+            # PROD-7888 : When requesting the scenario state right after a run has been submitted,
+            # the scenario run service (e.g., Argo Workflow) might not have scheduled the run
+            # effectively yet.
+            # Furthermore, temporary communication errors might occur anytime when remotely
+            # fetching last scenario run statuses.
+            - Unknown
         creationDate:
           type: string
           # for example, 2017-07-21T17:32:28Z

--- a/scenario/src/test/kotlin/com/cosmotech/scenario/azure/ScenarioServiceImplTests.kt
+++ b/scenario/src/test/kotlin/com/cosmotech/scenario/azure/ScenarioServiceImplTests.kt
@@ -415,7 +415,11 @@ class ScenarioServiceImplTests {
   @TestFactory
   fun `scenario state should be set to Failed when needed`() =
       buildDynamicTestsForWorkflowPhases(
-          Scenario.State.Failed, "Skipped", "Failed", "Error", "Omitted", null, "an-unknown-status")
+          Scenario.State.Failed, "Skipped", "Failed", "Error", "Omitted")
+
+  @TestFactory
+  fun `PROD-7888 - scenario state should be Unknown (rather than Failed) if workflow phase is null or not known to us`() =
+      buildDynamicTestsForWorkflowPhases(Scenario.State.Unknown, null, "an-unknown-status")
 
   private fun buildDynamicTestsForWorkflowPhases(
       expectedState: Scenario.State?,


### PR DESCRIPTION
This fixes [PROD-7888](https://spaceport.cosmotech.com/jira/browse/PROD-7888) by introducing a new `Unknown` state for Scenarios, used to handle cases where the status returned by Argo is `null` or not known to us.

There are few cases relevant for this:

- when fetching a scenario right after a successful run request, Argo Server returns a Workflow with a `status` field populated with `null` values, which is returned because the Workflow is about to be scheduled, but is not actually yet. This lasts just few seconds.
- a possible temporary communication error when reaching out to the Scenario Run Service for fetching statuses