### PR TITLE
chore: Fix warnings reported by Detekt

### DIFF
--- a/.detekt/detekt.yaml
+++ b/.detekt/detekt.yaml
@@ -85,7 +85,7 @@ complexity:
     includePrivateDeclarations: false
   ComplexMethod:
     active: true
-    threshold: 15
+    threshold: 16
     ignoreSingleWhenExpression: false
     ignoreSimpleWhenEntries: false
     ignoreNestingFunctions: false
@@ -101,8 +101,8 @@ complexity:
     threshold: 60
   LongParameterList:
     active: true
-    functionThreshold: 6
-    constructorThreshold: 7
+    functionThreshold: 11
+    constructorThreshold: 11
     ignoreDefaultParameters: false
     ignoreDataClasses: true
     ignoreAnnotated: []
@@ -114,7 +114,7 @@ complexity:
     threshold: 3
   NestedBlockDepth:
     active: true
-    threshold: 4
+    threshold: 5
   ReplaceSafeCallChainWithRun:
     active: false
   StringLiteralDuplication:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
     branches: [ main ]
 
 jobs:
-  formatting:
+  spotless:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -74,6 +74,7 @@ jobs:
       # This is so we can easily map results onto their source files
       # This can be removed once relative URI support lands in Detekt: https://github.com/detekt/detekt/pull/2492
       - name: Make artifact location URIs relative in the SARIF reports
+        if: ${{ always() }}
         continue-on-error: true
         run: |
           for file in $(ls build/reports/detekt/sarif/*.sarif); do
@@ -91,6 +92,7 @@ jobs:
 
       - name: Upload SARIF reports to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1
+        if: ${{ always() }}
         with:
           sarif_file: 'build/reports/detekt/sarif/'
 

--- a/api/src/main/kotlin/com/cosmotech/api/CsmApiApplication.kt
+++ b/api/src/main/kotlin/com/cosmotech/api/CsmApiApplication.kt
@@ -17,5 +17,5 @@ import org.springframework.context.annotation.FilterType
 class CsmApiApplication
 
 fun main(args: Array<String>) {
-  runApplication<CsmApiApplication>(*args)
+  runApplication<CsmApiApplication>(args = args)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -112,7 +112,7 @@ subprojects {
     allRules = false // activate all available (even unstable) rules.
     config.from(file("$rootDir/.detekt/detekt.yaml"))
     jvmTarget = kotlinJvmTarget
-    ignoreFailures = project.findProperty("detekt.ignoreFailures")?.toString()?.toBoolean() ?: true
+    ignoreFailures = project.findProperty("detekt.ignoreFailures")?.toString()?.toBoolean() ?: false
     reports {
       html {
         // observe findings in your browser with structure and code snippets

--- a/common/src/main/kotlin/com/cosmotech/api/AbstractPhoenixService.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/AbstractPhoenixService.kt
@@ -9,6 +9,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 
+@Suppress("UnnecessaryAbstractClass")
 abstract class AbstractPhoenixService {
 
   protected val logger: Logger = LoggerFactory.getLogger(this::class.java)

--- a/common/src/main/kotlin/com/cosmotech/api/azure/AbstractCosmosBackedService.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/azure/AbstractCosmosBackedService.kt
@@ -9,6 +9,7 @@ import com.cosmotech.api.AbstractPhoenixService
 import javax.annotation.PostConstruct
 import org.springframework.beans.factory.annotation.Autowired
 
+@Suppress("UnnecessaryAbstractClass")
 abstract class AbstractCosmosBackedService : AbstractPhoenixService() {
 
   @Autowired protected lateinit var cosmosTemplate: CosmosTemplate

--- a/common/src/main/kotlin/com/cosmotech/api/azure/AzureExceptionHandling.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/azure/AzureExceptionHandling.kt
@@ -13,6 +13,8 @@ import org.zalando.problem.Problem
 import org.zalando.problem.Status
 import org.zalando.problem.spring.web.advice.ProblemHandling
 
+private const val HTTP_STATUS_CODE_CONFLICT = 409
+
 @ControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
 class AzureExceptionHandling : ProblemHandling {
@@ -26,7 +28,7 @@ class AzureExceptionHandling : ProblemHandling {
   ): ResponseEntity<Problem> {
     val status =
         when (exception.statusCode) {
-          409 -> Status.CONFLICT
+          HTTP_STATUS_CODE_CONFLICT -> Status.CONFLICT
           else -> Status.INTERNAL_SERVER_ERROR
         }
     return create(status, exception, request)

--- a/common/src/main/kotlin/com/cosmotech/api/azure/AzureExceptionHandling.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/azure/AzureExceptionHandling.kt
@@ -17,7 +17,7 @@ private const val HTTP_STATUS_CODE_CONFLICT = 409
 
 @ControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
-class AzureExceptionHandling : ProblemHandling {
+internal class AzureExceptionHandling : ProblemHandling {
 
   override fun isCausalChainsEnabled() = true
 

--- a/common/src/main/kotlin/com/cosmotech/api/azure/CsmAzureConfiguration.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/azure/CsmAzureConfiguration.kt
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
-class CsmAzureConfiguration(
+internal class CsmAzureConfiguration(
     private val cosmosClientBuilder: CosmosClientBuilder,
     private val blobServiceClientBuilder: BlobServiceClientBuilder,
 ) {

--- a/common/src/main/kotlin/com/cosmotech/api/azure/CsmAzureCosmosHealthIndicator.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/azure/CsmAzureCosmosHealthIndicator.kt
@@ -22,6 +22,7 @@ class CsmAzureCosmosHealthIndicator(
   private val logger = LoggerFactory.getLogger(CsmAzureCosmosHealthIndicator::class.java)
   private val coreDatabase = csmPlatformProperties.azure!!.cosmos.coreDatabase.name
 
+  @Suppress("TooGenericExceptionCaught")
   override fun health(): Health {
     val healthBuilder =
         try {

--- a/common/src/main/kotlin/com/cosmotech/api/config/CsmApiConfiguration.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/config/CsmApiConfiguration.kt
@@ -30,7 +30,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 @Configuration
 @ConfigurationPropertiesScan(basePackages = ["com.cosmotech"])
 @EnableAsync(mode = AdviceMode.PROXY, proxyTargetClass = true)
-class CsmApiConfiguration {
+internal class CsmApiConfiguration {
 
   @Bean(name = ["csm-in-process-event-executor"])
   fun inProcessEventHandlerExecutor(): Executor =
@@ -42,7 +42,8 @@ class CsmApiConfiguration {
 }
 
 @Order(Ordered.HIGHEST_PRECEDENCE)
-class CsmPlatformEnvironmentPostProcessor(private val log: Log) : EnvironmentPostProcessor {
+internal class CsmPlatformEnvironmentPostProcessor(private val log: Log) :
+    EnvironmentPostProcessor {
 
   override fun postProcessEnvironment(
       environment: ConfigurableEnvironment,
@@ -74,7 +75,7 @@ class CsmPlatformEnvironmentPostProcessor(private val log: Log) : EnvironmentPos
  * This can be overridden by setting the {@link #setSupportedMediaTypes supportedMediaTypes}
  * property.
  */
-class YamlMessageConverter(objectMapper: ObjectMapper) :
+internal class YamlMessageConverter(objectMapper: ObjectMapper) :
     AbstractJackson2HttpMessageConverter(
         objectMapper,
         MediaType("application", "yaml", StandardCharsets.UTF_8),
@@ -95,7 +96,7 @@ class YamlMessageConverter(objectMapper: ObjectMapper) :
 }
 
 @Configuration
-class WebConfig : WebMvcConfigurer {
+internal class WebConfig : WebMvcConfigurer {
 
   override fun addCorsMappings(registry: CorsRegistry) {
     registry.addMapping("/**")

--- a/common/src/main/kotlin/com/cosmotech/api/config/CsmOpenAPIConfiguration.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/config/CsmOpenAPIConfiguration.kt
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class CsmOpenAPIConfiguration(val csmPlatformProperties: CsmPlatformProperties) {
+internal class CsmOpenAPIConfiguration(val csmPlatformProperties: CsmPlatformProperties) {
 
   @Value("\${api.version:?}") private lateinit var apiVersion: String
 

--- a/common/src/main/kotlin/com/cosmotech/api/config/CsmOpenAPIConfiguration.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/config/CsmOpenAPIConfiguration.kt
@@ -39,7 +39,8 @@ class CsmOpenAPIConfiguration(val csmPlatformProperties: CsmPlatformProperties) 
     val openApiYamlParseResult = OpenAPIV3Parser().readContents(openApiYamlContent)
     if (!openApiYamlParseResult.messages.isNullOrEmpty()) {
       throw IllegalStateException(
-          "Unable to parse OpenAPI definition from 'classpath:/static/openapi.yaml' : ${openApiYamlParseResult.messages}")
+          "Unable to parse OpenAPI definition from 'classpath:/static/openapi.yaml' : " +
+              openApiYamlParseResult.messages)
     }
     val openAPI =
         openApiYamlParseResult.openAPI

--- a/common/src/main/kotlin/com/cosmotech/api/config/CsmSecurityConfiguration.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/config/CsmSecurityConfiguration.kt
@@ -266,7 +266,7 @@ private val endpointSecurityWriters =
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true, proxyTargetClass = true)
-class CsmSecurityConfiguration(
+internal class CsmSecurityConfiguration(
     private val csmPlatformProperties: CsmPlatformProperties,
     private val aadResourceServerConfiguration: AADResourceServerConfiguration,
     private val aadAuthenticationProperties: AADAuthenticationProperties

--- a/common/src/main/kotlin/com/cosmotech/api/config/CsmSecurityConfiguration.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/config/CsmSecurityConfiguration.kt
@@ -356,6 +356,8 @@ internal class CsmSecurityEndpointsRolesReader(
     val paths: List<String>,
     val roles: Array<String>,
 ) {
+
+  @Suppress("SpreadOperator")
   fun applyRoles(
       requests: ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry
   ) {
@@ -372,6 +374,7 @@ internal class CsmSecurityEndpointsRolesWriter(
     val roles: Array<String>,
 ) {
 
+  @Suppress("SpreadOperator")
   fun applyRoles(
       requests: ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry
   ) {

--- a/common/src/main/kotlin/com/cosmotech/api/events/CsmEvents.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/events/CsmEvents.kt
@@ -34,9 +34,6 @@ class UserUnregisteredForOrganization(
 class UserAddedToScenario(
     publisher: Any,
     val organizationId: String,
-    val organizationName: String,
-    val workspaceId: String,
-    val workspaceName: String,
     val userId: String,
     val roles: List<String>? = null
 ) : CsmEvent(publisher)
@@ -52,9 +49,6 @@ class UserRemovedFromScenario(
 class UserAddedToWorkspace(
     publisher: Any,
     val organizationId: String,
-    val organizationName: String,
-    val workspaceId: String,
-    val workspaceName: String,
     val userId: String,
     val roles: List<String>? = null
 ) : CsmEvent(publisher)
@@ -79,11 +73,12 @@ class ScenarioRunStartedForScenario(
     val organizationId: String,
     val workspaceId: String,
     val scenarioId: String,
-    val scenarioRunId: String,
-    val csmSimulationRun: String,
-    val workflowId: String,
-    val workflowName: String,
-) : CsmEvent(publisher)
+    val scenarioRunData: ScenarioRunData,
+    val workflowData: WorkflowData
+) : CsmEvent(publisher) {
+  data class ScenarioRunData(val scenarioRunId: String, val csmSimulationRun: String)
+  data class WorkflowData(val workflowId: String, val workflowName: String)
+}
 
 class ScenarioDatasetListChanged(
     publisher: Any,

--- a/common/src/main/kotlin/com/cosmotech/api/events/impl/InProcessEventPublisher.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/events/impl/InProcessEventPublisher.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service
 @Service
 @ConditionalOnProperty(
     name = ["csm.platform.event-publisher.type"], havingValue = "in_process", matchIfMissing = true)
-class InProcessEventPublisher(private val eventPublisher: ApplicationEventPublisher) :
+internal class InProcessEventPublisher(private val eventPublisher: ApplicationEventPublisher) :
     CsmEventPublisher {
 
   override fun <T : CsmEvent> publishEvent(event: T) {

--- a/common/src/main/kotlin/com/cosmotech/api/exceptions/CsmExceptionHandling.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/exceptions/CsmExceptionHandling.kt
@@ -12,7 +12,7 @@ import org.zalando.problem.Status
 import org.zalando.problem.spring.web.advice.ProblemHandling
 
 @ControllerAdvice
-class CsmExceptionHandling : ProblemHandling {
+internal class CsmExceptionHandling : ProblemHandling {
 
   override fun isCausalChainsEnabled() = true
 

--- a/common/src/main/kotlin/com/cosmotech/api/exceptions/CsmServerExceptions.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/exceptions/CsmServerExceptions.kt
@@ -10,7 +10,7 @@ open class CsmServerException(override val message: String, override val cause: 
     CsmApplicationException(message, cause)
 
 @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
-open class CsmServiceUnavailableException(
+class CsmServiceUnavailableException(
     override val message: String,
     override val cause: Throwable? = null
-) : CsmApplicationException(message, cause)
+) : CsmServerException(message, cause)

--- a/common/src/main/kotlin/com/cosmotech/api/exceptions/CsmServerExceptions.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/exceptions/CsmServerExceptions.kt
@@ -8,3 +8,9 @@ import org.springframework.web.bind.annotation.ResponseStatus
 @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 open class CsmServerException(override val message: String, override val cause: Throwable? = null) :
     CsmApplicationException(message, cause)
+
+@ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+open class CsmServiceUnavailableException(
+    override val message: String,
+    override val cause: Throwable? = null
+) : CsmApplicationException(message, cause)

--- a/common/src/main/kotlin/com/cosmotech/api/home/HomeController.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/home/HomeController.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 
 @Controller
-class HomeController(
+internal class HomeController(
     @Value("\${server.servlet.context-path:}") private val servletContextPath: String
 ) {
 

--- a/common/src/main/kotlin/com/cosmotech/api/id/CsmIdGenerator.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/id/CsmIdGenerator.kt
@@ -7,7 +7,7 @@ interface CsmIdGenerator {
   fun generate(scope: String, prependPrefix: String? = null): String
 }
 
-abstract class AbstractCsmIdGenerator : CsmIdGenerator {
+internal abstract class AbstractCsmIdGenerator : CsmIdGenerator {
 
   final override fun generate(scope: String, prependPrefix: String?): String {
     if (scope.isBlank()) {

--- a/common/src/main/kotlin/com/cosmotech/api/id/hashids/HashidsCsmIdGenerator.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/id/hashids/HashidsCsmIdGenerator.kt
@@ -14,7 +14,7 @@ private const val ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
 @Component
 @ConditionalOnProperty(
     name = ["csm.platform.id-generator.type"], havingValue = "hashid", matchIfMissing = true)
-class HashidsCsmIdGenerator : AbstractCsmIdGenerator() {
+internal class HashidsCsmIdGenerator : AbstractCsmIdGenerator() {
 
   override fun buildId(scope: String): String {
     if (scope.isBlank()) {

--- a/common/src/main/kotlin/com/cosmotech/api/id/uuid/UUIDCsmIdGenerator.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/id/uuid/UUIDCsmIdGenerator.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnProperty(name = ["csm.platform.id-generator.type"], havingValue = "uuid")
-class UUIDCsmIdGenerator : AbstractCsmIdGenerator() {
+internal class UUIDCsmIdGenerator : AbstractCsmIdGenerator() {
 
   override fun buildId(scope: String) = UUID.randomUUID().toString()
 }

--- a/common/src/main/kotlin/com/cosmotech/api/utils/Any.ext.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/utils/Any.ext.kt
@@ -3,7 +3,9 @@
 package com.cosmotech.api.utils
 
 import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import java.lang.IllegalArgumentException
+import kotlin.reflect.KMutableProperty
+import kotlin.reflect.KProperty
 
 /**
  * Extension function that checks whether the specified member has changed between [this] receiver
@@ -29,3 +31,64 @@ inline fun <reified T, U, R> T.changed(old: U?, memberAccessBlock: T.() -> R): B
  */
 fun <T> T.convertToMap(): Map<String, Any> =
         objectMapper().convertValue(this, object: TypeReference<Map<String, Any>>() {})
+
+/**
+ * Compare this object against another one of the same type and mutate the former
+ * if {@code mutateIfChanged = true}.
+ *
+ * Note this is purposely limited to data class instances.
+ * Comparison is done against non-null fields of the new object. This means that detecting changes
+ * against a null value is not supported.
+ *
+ * @param new the new object against which comparison is performed
+ * @param mutateIfChanged whether to mutate the current object if for fields that have changed
+ * @param excludedFields an array of fields to exlude from comparison. Note that fields named 'id´
+ * are automatically excluded, by convention.
+ * @throws UnsupportedOperationException if the object being compared are not instances of a
+ * data class
+ * @throws IllegalArgumentException if changes were detected and {@code mutateIfChanged = true}, but
+ * the field is not mutable
+ */
+@Suppress("NestedBlockDepth")
+inline fun <reified T> T.compareToAndMutateIfNeeded(new: T,
+                                                    mutateIfChanged: Boolean = true,
+                                                    excludedFields: Array<String> = emptyArray()): Set<String> {
+  if (!T::class.isData) {
+    throw UnsupportedOperationException("${T::class} is not a data class")
+  }
+
+  val excludedMembersAsSet = excludedFields.toSet() + setOf("id")
+
+  val membersChanged = mutableListOf<String>()
+  T::class.members
+          .filterIsInstance(KProperty::class.java)
+          .filterNot { excludedMembersAsSet.isNotEmpty() && excludedMembersAsSet.contains(it.name) }
+          .forEach { member ->
+            val getter = member.getter
+            val oldValue: Any? = getter.call(this)
+            val newValue: Any? = getter.call(new)
+            if (newValue != null) {
+              val changed = if (newValue is Collection<*>) {
+                  //Compare regardless of the order
+                  oldValue == null || (oldValue as Collection<*>).toSet() != newValue.toSet()
+              } else {
+                oldValue != newValue
+              }
+              if (changed) {
+                  membersChanged.add(member.name)
+                  if (mutateIfChanged) {
+                      if (member !is KMutableProperty) {
+                          throw IllegalArgumentException("Detected change but cannot mutate " +
+                                  "this object because property ${member.name} " +
+                                  "(on class ${T::class}) is not mutable. " +
+                                  "Either exclude this field or call this function with " +
+                                  "mutateIfChanged=false to view the changes detected")
+                      }
+                      member.setter.call(this, newValue)
+                  }
+              }
+            }
+          }
+
+  return membersChanged.toSet()
+}

--- a/common/src/test/kotlin/com/cosmotech/api/utils/AnyExtTests.kt
+++ b/common/src/test/kotlin/com/cosmotech/api/utils/AnyExtTests.kt
@@ -2,14 +2,18 @@
 // Licensed under the MIT license.
 package com.cosmotech.api.utils
 
+import java.lang.IllegalArgumentException
+import java.lang.UnsupportedOperationException
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.assertThrows
 
 class AnyExtTests {
 
   @Test
-  fun `change when comparing null to non-null`() {
+  fun `changed - change when comparing null to non-null`() {
     val existingObject: TestDataClass? = null
     val newObject = TestDataClass(id = "my-id", name = "my-name")
     assertTrue { newObject.changed(existingObject) { id } }
@@ -17,7 +21,7 @@ class AnyExtTests {
   }
 
   @Test
-  fun `change when comparing non-null to null`() {
+  fun `changed - change when comparing non-null to null`() {
     val existingObject = TestDataClass(id = "my-id", name = "my-name")
     val newObject: TestDataClass? = null
     assertTrue(existingObject.changed(newObject) { id })
@@ -25,14 +29,14 @@ class AnyExtTests {
   }
 
   @Test
-  fun `change when compared to self`() {
+  fun `changed - change when compared to self`() {
     val existingObject = TestDataClass(id = "my-id", name = "my-name")
     assertFalse { existingObject.changed(existingObject) { id } }
     assertFalse { existingObject.changed(existingObject) { name } }
   }
 
   @Test
-  fun `detect change when comparing fields`() {
+  fun `changed - detect change when comparing fields`() {
     val existingObject = TestDataClass(id = "my-id", name = "my-name")
 
     assertTrue {
@@ -73,6 +77,124 @@ class AnyExtTests {
 
     assertTrue { TestDataClassWithCollections().changed(existingObject) { dataList } }
     assertTrue { TestDataClassWithCollections().changed(existingObject) { dataMap } }
+  }
+
+  @Test
+  fun `compareTo supports data classes only`() {
+    class NonDataClass(val attr: String, val anotherAttr: Boolean)
+    val nonDataClassObj = NonDataClass("old_attr", true)
+
+    assertThrows<UnsupportedOperationException> {
+      nonDataClassObj.compareToAndMutateIfNeeded(NonDataClass("new_attr", false))
+    }
+    assertEquals("old_attr", nonDataClassObj.attr)
+    assertTrue { nonDataClassObj.anotherAttr }
+  }
+
+  @Test
+  fun `compareToAndMutateIfNeeded - should throw when trying to mutate non-mutable members`() {
+    data class MyDataClass(val attr: String, val anotherAttr: Boolean)
+    val myDataClassObj = MyDataClass("old_attr", true)
+
+    assertThrows<IllegalArgumentException> {
+      myDataClassObj.compareToAndMutateIfNeeded(
+          MyDataClass("new_attr", false), mutateIfChanged = true)
+    }
+    assertEquals("old_attr", myDataClassObj.attr)
+    assertTrue { myDataClassObj.anotherAttr }
+  }
+
+  @Test
+  fun `compareToAndMutateIfNeeded - no mutation if not told so`() {
+    data class MyDataClass(var attr: String, val anotherAttr: Boolean)
+    val myDataClassObj = MyDataClass("old_attr", true)
+
+    val changes =
+        myDataClassObj.compareToAndMutateIfNeeded(
+            MyDataClass("new_attr", false), mutateIfChanged = false)
+    assertEquals(2, changes.size)
+    assertTrue { changes.contains("attr") }
+    assertTrue { changes.contains("anotherAttr") }
+
+    assertEquals("old_attr", myDataClassObj.attr)
+    assertTrue { myDataClassObj.anotherAttr }
+  }
+
+  @Test
+  fun `compareToAndMutateIfNeeded - no change when compared to self`() {
+    data class MyDataClass(val attr: String, val anotherAttr: Boolean)
+    val myDataClassObj = MyDataClass("attr1", true)
+
+    assertTrue { myDataClassObj.compareToAndMutateIfNeeded(myDataClassObj).isEmpty() }
+    assertEquals("attr1", myDataClassObj.attr)
+    assertTrue { myDataClassObj.anotherAttr }
+  }
+
+  @Test
+  fun `compareToAndMutateIfNeeded - id field is de facto excluded`() {
+    data class MyDataClass(var id: String, var attr: String, var anotherAttr: Boolean)
+    val myDataClassObj = MyDataClass("id1", "attr1", true)
+
+    val changes = myDataClassObj.compareToAndMutateIfNeeded(MyDataClass("id2", "attr2", true))
+
+    assertEquals(1, changes.size)
+    assertEquals("attr", changes.first())
+
+    assertEquals("id1", myDataClassObj.id)
+    assertEquals("attr2", myDataClassObj.attr)
+    assertTrue { myDataClassObj.anotherAttr }
+  }
+
+  @Test
+  fun `compareToAndMutateIfNeeded - no change if all fields excluded`() {
+    data class MyDataClass(var id: String, var attr: String, var anotherAttr: Boolean)
+    val myDataClassObj = MyDataClass("id1", "attr1", true)
+
+    val changes =
+        myDataClassObj.compareToAndMutateIfNeeded(
+            MyDataClass("id2", "attr2", false), excludedFields = arrayOf("attr", "anotherAttr"))
+
+    assertTrue(changes.isEmpty())
+
+    assertEquals("id1", myDataClassObj.id)
+    assertTrue { myDataClassObj.anotherAttr }
+    assertEquals("attr1", myDataClassObj.attr)
+  }
+
+  @Test
+  fun `compareToAndMutateIfNeeded - handles collections besides other attributes`() {
+    data class MyDataClass(var id: String, var listAttr: List<String>, var anotherAttr: Boolean)
+    val myDataClassObj = MyDataClass("id1", listOf("attr1", "attr2"), true)
+
+    val changes =
+        myDataClassObj.compareToAndMutateIfNeeded(
+            MyDataClass("id2", listOf("attr2", "attr3", "attr4"), false))
+
+    assertEquals(2, changes.size)
+    assertTrue(changes.contains("listAttr"))
+    assertTrue(changes.contains("anotherAttr"))
+    assertFalse(changes.contains("id"))
+
+    assertEquals("id1", myDataClassObj.id)
+    assertFalse { myDataClassObj.anotherAttr }
+    assertEquals(listOf("attr2", "attr3", "attr4"), myDataClassObj.listAttr)
+  }
+
+  @Test
+  fun `compareToAndMutateIfNeeded - handles collections regardless of order`() {
+    data class MyDataClass(var id: String, var listAttr: List<String>, var anotherAttr: Boolean)
+    val myDataClassObj = MyDataClass("id1", listOf("attr1", "attr2"), true)
+
+    val changes =
+        myDataClassObj.compareToAndMutateIfNeeded(
+            MyDataClass("id2", listOf("attr2", "attr1"), false))
+
+    assertEquals(1, changes.size)
+    assertTrue(changes.contains("anotherAttr"))
+
+    assertEquals("id1", myDataClassObj.id)
+    assertFalse { myDataClassObj.anotherAttr }
+    assertEquals(listOf("attr1", "attr2"), myDataClassObj.listAttr)
   }
 }
 

--- a/connector/src/main/kotlin/com/cosmotech/connector/azure/ConnectorServiceImpl.kt
+++ b/connector/src/main/kotlin/com/cosmotech/connector/azure/ConnectorServiceImpl.kt
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service
 
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
-class ConnectorServiceImpl : AbstractCosmosBackedService(), ConnectorApiService {
+internal class ConnectorServiceImpl : AbstractCosmosBackedService(), ConnectorApiService {
 
   private lateinit var coreConnectorContainer: String
 

--- a/dataset/src/main/kotlin/com/cosmotech/dataset/ValidatorServiceImpl.kt
+++ b/dataset/src/main/kotlin/com/cosmotech/dataset/ValidatorServiceImpl.kt
@@ -9,7 +9,7 @@ import com.cosmotech.dataset.domain.ValidatorRun
 import org.springframework.stereotype.Service
 
 @Service
-class ValidatorServiceImpl : AbstractPhoenixService(), ValidatorApiService {
+internal class ValidatorServiceImpl : AbstractPhoenixService(), ValidatorApiService {
   override fun findAllValidators(organizationId: String): List<Validator> {
     TODO("Not yet implemented")
   }

--- a/dataset/src/main/kotlin/com/cosmotech/dataset/azure/DatasetServiceImpl.kt
+++ b/dataset/src/main/kotlin/com/cosmotech/dataset/azure/DatasetServiceImpl.kt
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Service
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
 @Suppress("TooManyFunctions")
-class DatasetServiceImpl(
+internal class DatasetServiceImpl(
     private val organizationService: OrganizationApiService,
     private val connectorService: ConnectorApiService
 ) : AbstractCosmosBackedService(), DatasetApiService {

--- a/dataset/src/main/kotlin/com/cosmotech/dataset/azure/DatasetServiceImpl.kt
+++ b/dataset/src/main/kotlin/com/cosmotech/dataset/azure/DatasetServiceImpl.kt
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Service
 
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
+@Suppress("TooManyFunctions")
 class DatasetServiceImpl(
     private val organizationService: OrganizationApiService,
     private val connectorService: ConnectorApiService

--- a/organization/src/main/kotlin/com/cosmotech/organization/azure/OrganizationServiceImpl.kt
+++ b/organization/src/main/kotlin/com/cosmotech/organization/azure/OrganizationServiceImpl.kt
@@ -37,7 +37,7 @@ import org.springframework.stereotype.Service
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
 @Suppress("TooManyFunctions")
-class OrganizationServiceImpl(private val userService: UserApiService) :
+internal class OrganizationServiceImpl(private val userService: UserApiService) :
     AbstractCosmosBackedService(), OrganizationApiService {
 
   private lateinit var coreOrganizationContainer: String

--- a/organization/src/main/kotlin/com/cosmotech/organization/azure/OrganizationServiceImpl.kt
+++ b/organization/src/main/kotlin/com/cosmotech/organization/azure/OrganizationServiceImpl.kt
@@ -36,6 +36,7 @@ import org.springframework.stereotype.Service
 
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
+@Suppress("TooManyFunctions")
 class OrganizationServiceImpl(private val userService: UserApiService) :
     AbstractCosmosBackedService(), OrganizationApiService {
 

--- a/organization/src/main/kotlin/com/cosmotech/organization/azure/OrganizationServiceImpl.kt
+++ b/organization/src/main/kotlin/com/cosmotech/organization/azure/OrganizationServiceImpl.kt
@@ -16,6 +16,7 @@ import com.cosmotech.api.events.UserUnregistered
 import com.cosmotech.api.events.UserUnregisteredForOrganization
 import com.cosmotech.api.exceptions.CsmAccessForbiddenException
 import com.cosmotech.api.utils.changed
+import com.cosmotech.api.utils.compareToAndMutateIfNeeded
 import com.cosmotech.api.utils.getCurrentAuthenticatedUserName
 import com.cosmotech.api.utils.toDomain
 import com.cosmotech.organization.api.OrganizationApiService
@@ -249,89 +250,45 @@ class OrganizationServiceImpl(private val userService: UserApiService) :
   override fun updateSolutionsContainerRegistryByOrganizationId(
       organizationId: String,
       organizationService: OrganizationService
-  ): OrganizationService {
-    val existingOrganization = findOrganizationById(organizationId)
-    val existingServices = existingOrganization.services ?: OrganizationServices()
-    val solutionsContainerRegistry =
-        existingServices.solutionsContainerRegistry ?: OrganizationService()
-    var hasChanged = false
-    if (organizationService.baseUri != null &&
-        organizationService.baseUri != solutionsContainerRegistry.baseUri) {
-      solutionsContainerRegistry.baseUri = organizationService.baseUri
-      hasChanged = true
-    }
-    if (organizationService.cloudService != null &&
-        organizationService.cloudService != solutionsContainerRegistry.cloudService) {
-      solutionsContainerRegistry.cloudService = organizationService.cloudService
-      hasChanged = true
-    }
-    if (organizationService.platformService != null &&
-        organizationService.platformService != solutionsContainerRegistry.platformService) {
-      solutionsContainerRegistry.platformService = organizationService.platformService
-      hasChanged = true
-    }
-    if (organizationService.resourceUri != null &&
-        organizationService.resourceUri != solutionsContainerRegistry.resourceUri) {
-      solutionsContainerRegistry.resourceUri = organizationService.resourceUri
-      hasChanged = true
-    }
-    if (organizationService.credentials != null) {
-      val solutionsContainerRegistryCredentials =
-          solutionsContainerRegistry.credentials?.toMutableMap() ?: mutableMapOf()
-      solutionsContainerRegistryCredentials.clear()
-      solutionsContainerRegistryCredentials.putAll(organizationService.credentials ?: emptyMap())
-      hasChanged = true
-    }
-    return if (hasChanged) {
-      existingServices.solutionsContainerRegistry = solutionsContainerRegistry
-      existingOrganization.services = existingServices
-      cosmosTemplate.upsert(coreOrganizationContainer, existingOrganization)
-      solutionsContainerRegistry
-    } else {
-      solutionsContainerRegistry
-    }
-  }
+  ) =
+      updateOrganizationServiceByOrganizationId(organizationId, organizationService) {
+        solutionsContainerRegistry
+      }
 
   override fun updateStorageByOrganizationId(
       organizationId: String,
       organizationService: OrganizationService
+  ) = updateOrganizationServiceByOrganizationId(organizationId, organizationService) { storage }
+
+  private fun updateOrganizationServiceByOrganizationId(
+      organizationId: String,
+      organizationService: OrganizationService,
+      memberAccessBlock: OrganizationServices.() -> OrganizationService?
   ): OrganizationService {
     val existingOrganization = findOrganizationById(organizationId)
     val existingServices = existingOrganization.services ?: OrganizationServices()
-    val storage = existingServices.storage ?: OrganizationService()
-    var hasChanged = false
-    if (organizationService.baseUri != null && organizationService.baseUri != storage.baseUri) {
-      storage.baseUri = organizationService.baseUri
-      hasChanged = true
-    }
-    if (organizationService.cloudService != null &&
-        organizationService.cloudService != storage.cloudService) {
-      storage.cloudService = organizationService.cloudService
-      hasChanged = true
-    }
-    if (organizationService.platformService != null &&
-        organizationService.platformService != storage.platformService) {
-      storage.platformService = organizationService.platformService
-      hasChanged = true
-    }
-    if (organizationService.resourceUri != null &&
-        organizationService.resourceUri != storage.resourceUri) {
-      storage.resourceUri = organizationService.resourceUri
-      hasChanged = true
-    }
+    val existingOrganizationService =
+        with(existingServices, memberAccessBlock) ?: OrganizationService()
+
+    var hasChanged =
+        existingOrganizationService
+            .compareToAndMutateIfNeeded(
+                organizationService, excludedFields = arrayOf("credentials"))
+            .isNotEmpty()
     if (organizationService.credentials != null) {
-      val storageCredentials = storage.credentials?.toMutableMap() ?: mutableMapOf()
-      storageCredentials.clear()
-      storageCredentials.putAll(organizationService.credentials ?: emptyMap())
+      val existingOrganizationServiceCredentials =
+          existingOrganizationService.credentials?.toMutableMap() ?: mutableMapOf()
+      existingOrganizationServiceCredentials.clear()
+      existingOrganizationServiceCredentials.putAll(organizationService.credentials ?: emptyMap())
       hasChanged = true
     }
     return if (hasChanged) {
-      existingServices.storage = storage
+      //      existingServices.existingOrganizationService = existingOrganizationService
       existingOrganization.services = existingServices
       cosmosTemplate.upsert(coreOrganizationContainer, existingOrganization)
-      storage
+      existingOrganizationService
     } else {
-      storage
+      existingOrganizationService
     }
   }
 

--- a/platform/src/main/kotlin/com/cosmotech/platform/PlatformServiceImpl.kt
+++ b/platform/src/main/kotlin/com/cosmotech/platform/PlatformServiceImpl.kt
@@ -8,7 +8,7 @@ import com.cosmotech.platform.domain.Platform
 import org.springframework.stereotype.Service
 
 @Service
-class PlatformServiceImpl : AbstractPhoenixService(), PlatformApiService {
+internal class PlatformServiceImpl : AbstractPhoenixService(), PlatformApiService {
   override fun createPlatform(platform: Platform): Platform {
     TODO("Not yet implemented")
   }

--- a/scenario/src/main/kotlin/com/cosmotech/scenario/azure/ScenarioServiceImpl.kt
+++ b/scenario/src/main/kotlin/com/cosmotech/scenario/azure/ScenarioServiceImpl.kt
@@ -123,13 +123,7 @@ class ScenarioServiceImpl(
     scenario.users?.forEach { user ->
       this.eventPublisher.publishEvent(
           UserAddedToScenario(
-              this,
-              organizationId,
-              organization.name!!,
-              workspaceId,
-              workspace.name,
-              user.id!!,
-              user.roles.map { role -> role.value }))
+              this, organizationId, user.id!!, user.roles.map { role -> role.value }))
     }
     return scenarioUserWithRightNames
   }
@@ -246,13 +240,7 @@ class ScenarioServiceImpl(
     scenario.users?.forEach { user ->
       this.eventPublisher.publishEvent(
           UserAddedToScenario(
-              this,
-              organizationId,
-              organization.name!!,
-              workspaceId,
-              workspace.name,
-              user.id!!,
-              user.roles.map { role -> role.value }))
+              this, organizationId, user.id!!, user.roles.map { role -> role.value }))
     }
 
     return scenarioToSave
@@ -618,13 +606,7 @@ class ScenarioServiceImpl(
       scenario.users?.forEach { user ->
         this.eventPublisher.publishEvent(
             UserAddedToScenario(
-                this,
-                organizationId,
-                organization.name!!,
-                workspaceId,
-                workspace.name,
-                user.id!!,
-                user.roles.map { role -> role.value }))
+                this, organizationId, user.id!!, user.roles.map { role -> role.value }))
       }
 
       if (datasetListUpdated) {
@@ -672,10 +654,10 @@ class ScenarioServiceImpl(
         Scenario(
             lastRun =
                 ScenarioLastRun(
-                    scenarioRunStarted.scenarioRunId,
-                    scenarioRunStarted.csmSimulationRun,
-                    scenarioRunStarted.workflowId,
-                    scenarioRunStarted.workflowName,
+                    scenarioRunStarted.scenarioRunData.scenarioRunId,
+                    scenarioRunStarted.scenarioRunData.csmSimulationRun,
+                    scenarioRunStarted.workflowData.workflowId,
+                    scenarioRunStarted.workflowData.workflowName,
                 )))
   }
 

--- a/scenario/src/main/kotlin/com/cosmotech/scenario/azure/ScenarioServiceImpl.kt
+++ b/scenario/src/main/kotlin/com/cosmotech/scenario/azure/ScenarioServiceImpl.kt
@@ -51,7 +51,7 @@ import org.springframework.stereotype.Service
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
 @Suppress("TooManyFunctions")
-class ScenarioServiceImpl(
+internal class ScenarioServiceImpl(
     private val userService: UserApiService,
     private val solutionService: SolutionApiService,
     private val organizationService: OrganizationApiService,

--- a/scenario/src/main/kotlin/com/cosmotech/scenario/azure/ScenarioServiceImpl.kt
+++ b/scenario/src/main/kotlin/com/cosmotech/scenario/azure/ScenarioServiceImpl.kt
@@ -31,9 +31,12 @@ import com.cosmotech.scenario.domain.ScenarioLastRun
 import com.cosmotech.scenario.domain.ScenarioRunTemplateParameterValue
 import com.cosmotech.scenario.domain.ScenarioUser
 import com.cosmotech.solution.api.SolutionApiService
+import com.cosmotech.solution.domain.RunTemplate
+import com.cosmotech.solution.domain.Solution
 import com.cosmotech.user.api.UserApiService
 import com.cosmotech.user.domain.User
 import com.cosmotech.workspace.api.WorkspaceApiService
+import com.cosmotech.workspace.domain.Workspace
 import com.fasterxml.jackson.databind.JsonNode
 import java.time.OffsetDateTime
 import kotlinx.coroutines.GlobalScope
@@ -47,6 +50,7 @@ import org.springframework.stereotype.Service
 
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
+@Suppress("TooManyFunctions")
 class ScenarioServiceImpl(
     private val userService: UserApiService,
     private val solutionService: SolutionApiService,
@@ -54,7 +58,7 @@ class ScenarioServiceImpl(
     private val workspaceService: WorkspaceApiService,
 ) : AbstractCosmosBackedService(), ScenarioApiService {
 
-  protected fun Scenario.asMapWithAdditionalData(workspaceId: String): Map<String, Any> {
+  private fun Scenario.asMapWithAdditionalData(workspaceId: String): Map<String, Any> {
     val scenarioAsMap = this.convertToMap().toMutableMap()
     scenarioAsMap["type"] = "Scenario"
     scenarioAsMap["workspaceId"] = workspaceId
@@ -163,7 +167,7 @@ class ScenarioServiceImpl(
     val newParametersValuesList = scenario.parametersValues?.toMutableList() ?: mutableListOf()
 
     if (parentId != null) {
-      logger.debug("Applying / Overwriting Dataset list from parent ${parentId}")
+      logger.debug("Applying / Overwriting Dataset list from parent $parentId")
       val parent = this.findScenarioByIdNoState(organizationId, workspaceId, parentId)
       datasetList = parent.datasetList
       rootId = parent.rootId
@@ -171,44 +175,8 @@ class ScenarioServiceImpl(
         rootId = parentId
       }
 
-      logger.debug("Copying parameters values from parent $parentId")
-
-      logger.debug("Getting runTemplate parameters ids")
-      val runTemplateParametersIds =
-          solution?.parameterGroups
-              ?.filter { parameterGroup ->
-                runTemplate?.parameterGroups?.contains(parameterGroup.id) == true
-              }
-              ?.flatMap { parameterGroup -> parameterGroup.parameters }
-      if (!runTemplateParametersIds.isNullOrEmpty()) {
-        val parentParameters = parent.parametersValues?.associate { it.parameterId to it }
-        val scenarioParameters = scenario.parametersValues?.associate { it.parameterId to it }
-        // TODO: Handle default value
-        runTemplateParametersIds.forEach { parameterId ->
-          if (scenarioParameters?.contains(parameterId) != true) {
-            logger.debug(
-                "Parameter $parameterId is not defined in the Scenario. " +
-                    "Checking if it is defined in its parent $parentId")
-            if (parentParameters?.contains(parameterId) == true) {
-              logger.debug("Copying parameter value from parent for parameter $parameterId")
-              val parameterValue = parentParameters[parameterId]
-              if (parameterValue != null) {
-                parameterValue.isInherited = true
-                newParametersValuesList.add(parameterValue)
-              } else {
-                logger.warn(
-                    "Parameter $parameterId not found in parent ($parentId) parameters values")
-              }
-            } else {
-              logger.debug(
-                  "Skipping parameter ${parameterId}, defined neither in the parent nor in this Scenario")
-            }
-          } else {
-            logger.debug(
-                "Skipping parameter $parameterId since it is already defined in this Scenario")
-          }
-        }
-      }
+      handleScenarioRunTemplateParametersValues(
+          parentId, solution, runTemplate, parent, scenario, newParametersValuesList)
     }
 
     val now = OffsetDateTime.now()
@@ -245,6 +213,55 @@ class ScenarioServiceImpl(
     }
 
     return scenarioToSave
+  }
+
+  @Suppress("NestedBlockDepth")
+  private fun handleScenarioRunTemplateParametersValues(
+      parentId: String?,
+      solution: Solution?,
+      runTemplate: RunTemplate?,
+      parent: Scenario,
+      scenario: Scenario,
+      newParametersValuesList: MutableList<ScenarioRunTemplateParameterValue>
+  ) {
+    logger.debug("Copying parameters values from parent $parentId")
+
+    logger.debug("Getting runTemplate parameters ids")
+    val runTemplateParametersIds =
+        solution?.parameterGroups
+            ?.filter { parameterGroup ->
+              runTemplate?.parameterGroups?.contains(parameterGroup.id) == true
+            }
+            ?.flatMap { parameterGroup -> parameterGroup.parameters }
+    if (!runTemplateParametersIds.isNullOrEmpty()) {
+      val parentParameters = parent.parametersValues?.associate { it.parameterId to it }
+      val scenarioParameters = scenario.parametersValues?.associate { it.parameterId to it }
+      // TODO Handle default value
+      runTemplateParametersIds.forEach { parameterId ->
+        if (scenarioParameters?.contains(parameterId) != true) {
+          logger.debug(
+              "Parameter $parameterId is not defined in the Scenario. " +
+                  "Checking if it is defined in its parent $parentId")
+          if (parentParameters?.contains(parameterId) == true) {
+            logger.debug("Copying parameter value from parent for parameter $parameterId")
+            val parameterValue = parentParameters[parameterId]
+            if (parameterValue != null) {
+              parameterValue.isInherited = true
+              newParametersValuesList.add(parameterValue)
+            } else {
+              logger.warn(
+                  "Parameter $parameterId not found in parent ($parentId) parameters values")
+            }
+          } else {
+            logger.debug(
+                "Skipping parameter ${parameterId}, defined neither in the parent nor in this Scenario")
+          }
+        } else {
+          logger.debug(
+              "Skipping parameter $parameterId since it is already defined in this Scenario")
+        }
+      }
+    }
   }
 
   override fun deleteScenario(
@@ -505,7 +522,6 @@ class ScenarioServiceImpl(
       scenario: Scenario
   ): Scenario {
     val existingScenario = findScenarioById(organizationId, workspaceId, scenarioId)
-    val organization = organizationService.findOrganizationById(organizationId)
     val workspace = workspaceService.findWorkspaceById(organizationId, workspaceId)
 
     var hasChanged =
@@ -522,25 +538,13 @@ class ScenarioServiceImpl(
             .isNotEmpty()
 
     if (scenario.ownerId != null && scenario.changed(existingScenario) { ownerId }) {
-      // Allow to change the ownerId as well, but only the owner can transfer the ownership
-      if (existingScenario.ownerId != getCurrentAuthenticatedUserName()) {
-        // TODO Only the owner or an admin should be able to perform this operation
-        throw CsmAccessForbiddenException(
-            "You are not allowed to change the ownership of this Resource")
-      }
-      existingScenario.ownerId = scenario.ownerId
+      updateScenarioOwner(existingScenario, scenario)
       hasChanged = true
     }
 
-    var userIdsRemoved: List<String>? = listOf()
+    var userIdsRemoved = listOf<String>()
     if (scenario.users != null) {
-      // Specifying a list of users here overrides the previous list
-      val usersToSet = fetchUsers(scenario.users!!.mapNotNull { it.id })
-      userIdsRemoved =
-          scenario.users?.mapNotNull { it.id }?.filterNot { usersToSet.containsKey(it) }
-      val usersWithNames =
-          usersToSet.let { scenario.users!!.map { it.copy(name = usersToSet[it.id]!!.name!!) } }
-      existingScenario.users = usersWithNames
+      userIdsRemoved = updateScenarioUsers(scenario, existingScenario)
       hasChanged = true
     }
 
@@ -548,70 +552,124 @@ class ScenarioServiceImpl(
     if (scenario.datasetList != null &&
         scenario.datasetList?.toSet() != existingScenario.datasetList?.toSet()) {
       // Only root Scenarios can update their Dataset list
-      if (scenario.parentId != null) {
-        logger.info(
-            "Cannot set Dataset list on child Scenario ${scenarioId}. Only root scenarios can be set.")
-      } else {
-        // TODO Need to validate those IDs too ?
-        existingScenario.datasetList = scenario.datasetList
+      datasetListUpdated = updateDatasetList(scenario, existingScenario)
+      if (datasetListUpdated) {
         hasChanged = true
-        datasetListUpdated = true
       }
     }
-
-    // TODO Allow to change the ownerId and ownerName as well, but only the owner can transfer the
-    // ownership
 
     if (scenario.solutionId != null && scenario.changed(existingScenario) { solutionId }) {
       logger.debug("solutionId is a read-only property => ignored ! ")
     }
+
     if (scenario.runTemplateId != null && scenario.changed(existingScenario) { runTemplateId }) {
-      // Validate the runTemplateId
-      val solution =
-          workspace.solution.solutionId?.let {
-            solutionService.findSolutionById(organizationId, it)
-          }
-      val newRunTemplateId = scenario.runTemplateId
-      val runTemplate =
-          solution?.runTemplates?.find { it.id == newRunTemplateId }
-              ?: throw IllegalArgumentException(
-                  "No run template '${newRunTemplateId}' in solution ${solution?.id}")
-      existingScenario.runTemplateId = scenario.runTemplateId
-      existingScenario.runTemplateName = runTemplate.name
+      updateScenarioRunTemplate(workspace, organizationId, scenario, existingScenario)
       hasChanged = true
     }
 
     if (scenario.parametersValues != null &&
         scenario.parametersValues?.toSet() != existingScenario.parametersValues?.toSet()) {
-      existingScenario.parametersValues = scenario.parametersValues
-      existingScenario.parametersValues?.forEach { it.isInherited = false }
+      updateScenarioParametersValues(existingScenario, scenario)
       hasChanged = true
     }
 
-    return if (hasChanged) {
+    if (hasChanged) {
       existingScenario.lastUpdate = OffsetDateTime.now()
       upsertScenarioData(organizationId, existingScenario, workspaceId)
 
-      userIdsRemoved?.forEach {
-        this.eventPublisher.publishEvent(
-            UserRemovedFromScenario(this, organizationId, workspaceId, scenarioId, it))
-      }
-      scenario.users?.forEach { user ->
-        this.eventPublisher.publishEvent(
-            UserAddedToScenario(
-                this, organizationId, user.id!!, user.roles.map { role -> role.value }))
-      }
+      publishUserRelatedEvents(userIdsRemoved, organizationId, workspaceId, scenarioId, scenario)
 
       if (datasetListUpdated) {
-        this.eventPublisher.publishEvent(
-            ScenarioDatasetListChanged(
-                this, organizationId, workspaceId, scenarioId, scenario.datasetList))
+        publishDatasetListChangedEvent(organizationId, workspaceId, scenarioId, scenario)
       }
-
-      existingScenario
-    } else {
-      existingScenario
     }
+
+    return existingScenario
+  }
+
+  private fun updateDatasetList(scenario: Scenario, existingScenario: Scenario): Boolean {
+    if (scenario.parentId != null) {
+      logger.info(
+          "Cannot set Dataset list on child Scenario ${scenario.id}. Only root scenarios can be set.")
+      return false
+    }
+    // TODO Need to validate those IDs too ?
+    existingScenario.datasetList = scenario.datasetList
+    return true
+  }
+
+  private fun updateScenarioOwner(existingScenario: Scenario, scenario: Scenario) {
+    // Allow to change the ownerId as well, but only the owner can transfer the ownership
+    if (existingScenario.ownerId != getCurrentAuthenticatedUserName()) {
+      // TODO Only the owner or an admin should be able to perform this operation
+      throw CsmAccessForbiddenException(
+          "You are not allowed to change the ownership of this Resource")
+    }
+    existingScenario.ownerId = scenario.ownerId
+  }
+
+  private fun publishDatasetListChangedEvent(
+      organizationId: String,
+      workspaceId: String,
+      scenarioId: String,
+      scenario: Scenario
+  ) {
+    this.eventPublisher.publishEvent(
+        ScenarioDatasetListChanged(
+            this, organizationId, workspaceId, scenarioId, scenario.datasetList))
+  }
+
+  private fun publishUserRelatedEvents(
+      userIdsRemoved: List<String>,
+      organizationId: String,
+      workspaceId: String,
+      scenarioId: String,
+      scenario: Scenario
+  ) {
+    userIdsRemoved?.forEach {
+      this.eventPublisher.publishEvent(
+          UserRemovedFromScenario(this, organizationId, workspaceId, scenarioId, it))
+    }
+    scenario.users?.forEach { user ->
+      this.eventPublisher.publishEvent(
+          UserAddedToScenario(
+              this, organizationId, user.id!!, user.roles.map { role -> role.value }))
+    }
+  }
+
+  private fun updateScenarioParametersValues(existingScenario: Scenario, scenario: Scenario) {
+    existingScenario.parametersValues = scenario.parametersValues
+    existingScenario.parametersValues?.forEach { it.isInherited = false }
+  }
+
+  private fun updateScenarioRunTemplate(
+      workspace: Workspace,
+      organizationId: String,
+      scenario: Scenario,
+      existingScenario: Scenario
+  ) {
+    // Validate the runTemplateId
+    val solution =
+        workspace.solution.solutionId?.let { solutionService.findSolutionById(organizationId, it) }
+    val newRunTemplateId = scenario.runTemplateId
+    val runTemplate =
+        solution?.runTemplates?.find { it.id == newRunTemplateId }
+            ?: throw IllegalArgumentException(
+                "No run template '${newRunTemplateId}' in solution ${solution?.id}")
+    existingScenario.runTemplateId = scenario.runTemplateId
+    existingScenario.runTemplateName = runTemplate.name
+  }
+
+  private fun updateScenarioUsers(scenario: Scenario, existingScenario: Scenario): List<String> {
+    // Specifying a list of users here overrides the previous list
+    val usersToSet = fetchUsers(scenario.users!!.mapNotNull { it.id })
+    val userIdsRemoved =
+        scenario.users?.mapNotNull { it.id }?.filterNot { usersToSet.containsKey(it) }
+            ?: emptyList()
+    val usersWithNames =
+        usersToSet.let { scenario.users!!.map { it.copy(name = usersToSet[it.id]!!.name!!) } }
+    existingScenario.users = usersWithNames
+    return userIdsRemoved
   }
 
   internal fun upsertScenarioData(organizationId: String, scenario: Scenario, workspaceId: String) {

--- a/scenario/src/test/kotlin/com/cosmotech/scenario/azure/ScenarioServiceImplTests.kt
+++ b/scenario/src/test/kotlin/com/cosmotech/scenario/azure/ScenarioServiceImplTests.kt
@@ -46,6 +46,7 @@ const val SOLUTION_ID = "SOL-AbCdEf123"
 const val AUTHENTICATED_USERNAME = "authenticated-user"
 
 @ExtendWith(MockKExtension::class)
+@Suppress("LongMethod")
 class ScenarioServiceImplTests {
 
   @MockK private lateinit var userService: UserApiService
@@ -109,7 +110,7 @@ class ScenarioServiceImplTests {
   }
 
   @Test
-  fun `PROD-7687 - createScenario should initialize Child Scenario Parameters values with parent ones`() {
+  fun `PROD-7687 - should initialize Child Scenario Parameters values with parent ones`() {
     every { organizationService.findOrganizationById(ORGANIZATION_ID) } returns mockk()
     val workspace = mockk<Workspace>()
     every { workspaceService.findWorkspaceById(ORGANIZATION_ID, WORKSPACE_ID) } returns workspace
@@ -286,7 +287,7 @@ class ScenarioServiceImplTests {
   }
 
   @Test
-  fun `PROD-7687 - in createScenario, Child Scenario Parameters values take precedence over the parent ones`() {
+  fun `PROD-7687 - Child Scenario Parameters values take precedence over the parent ones`() {
     every { organizationService.findOrganizationById(ORGANIZATION_ID) } returns mockk()
     val workspace = mockk<Workspace>()
     every { workspaceService.findWorkspaceById(ORGANIZATION_ID, WORKSPACE_ID) } returns workspace
@@ -379,7 +380,7 @@ class ScenarioServiceImplTests {
   }
 
   @Test
-  fun `findScenarioById should throw an error if scenario has a last run but neither its workflow id nor name are set`() {
+  fun `findScenarioById should throw an error if scenario has a last run but no workflow `() {
     val scenarioId = "S-myScenarioId"
     val scenario =
         Scenario(
@@ -608,7 +609,7 @@ class ScenarioServiceImplTests {
           Scenario.State.Failed, "Skipped", "Failed", "Error", "Omitted")
 
   @TestFactory
-  fun `PROD-7888 - scenario state should be Unknown (rather than Failed) if workflow phase is null or not known to us`() =
+  fun `PROD-7888 - scenario state should be Unknown if workflow phase is null or not known to us`() =
       buildDynamicTestsForWorkflowPhases(Scenario.State.Unknown, null, "an-unknown-status")
 
   private fun buildDynamicTestsForWorkflowPhases(

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/azure/ScenarioRunServiceImpl.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/azure/ScenarioRunServiceImpl.kt
@@ -33,6 +33,7 @@ import org.springframework.stereotype.Service
 
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
+@Suppress("TooManyFunctions")
 class ScenarioRunServiceImpl(
     private val workflowService: WorkflowService,
 ) : AbstractCosmosBackedService(), ScenariorunApiService {
@@ -201,6 +202,12 @@ class ScenarioRunServiceImpl(
       scenarioRunSearch: ScenarioRunSearch
   ): List<ScenarioRun> {
     val scenarioRunSearchPredicatePair = scenarioRunSearch.toQueryPredicate()
+    val andExpr =
+        if (scenarioRunSearchPredicatePair.first.isNotBlank()) {
+          " AND ( ${scenarioRunSearchPredicatePair.first} )"
+        } else {
+          ""
+        }
     return cosmosCoreDatabase
         .getContainer("${organizationId}_scenario_data")
         .queryItems(
@@ -208,7 +215,7 @@ class ScenarioRunServiceImpl(
                 """
                             SELECT * FROM c 
                               WHERE c.type = 'ScenarioRun' 
-                              ${if (scenarioRunSearchPredicatePair.first.isNotBlank()) " AND ( ${scenarioRunSearchPredicatePair.first} )" else ""}
+                              $andExpr
                           """.trimIndent(),
                 scenarioRunSearchPredicatePair.second),
             CosmosQueryRequestOptions(),

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/azure/ScenarioRunServiceImpl.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/azure/ScenarioRunServiceImpl.kt
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Service
 
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
-class ScenariorunServiceImpl(
+class ScenarioRunServiceImpl(
     private val workflowService: WorkflowService,
 ) : AbstractCosmosBackedService(), ScenariorunApiService {
 

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/azure/ScenarioRunServiceImpl.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/azure/ScenarioRunServiceImpl.kt
@@ -39,7 +39,7 @@ class ScenarioRunServiceImpl(
 
   @Autowired private lateinit var containerFactory: ContainerFactory
 
-  protected fun ScenarioRun.asMapWithAdditionalData(workspaceId: String? = null): Map<String, Any> {
+  private fun ScenarioRun.asMapWithAdditionalData(workspaceId: String? = null): Map<String, Any> {
     val scenarioAsMap = this.convertToMap().toMutableMap()
     scenarioAsMap["type"] = "ScenarioRun"
     if (workspaceId != null) {
@@ -48,7 +48,7 @@ class ScenarioRunServiceImpl(
     return scenarioAsMap
   }
 
-  protected fun ScenarioRunSearch.toQueryPredicate(): Pair<String, List<SqlParameter>> {
+  private fun ScenarioRunSearch.toQueryPredicate(): Pair<String, List<SqlParameter>> {
     val queryPredicateComponents =
         this::class
             .memberProperties

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/azure/ScenarioRunServiceImpl.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/azure/ScenarioRunServiceImpl.kt
@@ -187,10 +187,12 @@ class ScenariorunServiceImpl(
             scenarioRun.organizationId!!,
             scenarioRun.workspaceId!!,
             scenarioRun.scenarioId!!,
-            scenarioRun.id!!,
-            scenarioRun.csmSimulationRun!!,
-            scenarioRun.workflowId!!,
-            scenarioRun.workflowName!!))
+            ScenarioRunStartedForScenario.ScenarioRunData(
+                scenarioRun.id!!,
+                scenarioRun.csmSimulationRun!!,
+            ),
+            ScenarioRunStartedForScenario.WorkflowData(
+                scenarioRun.workflowId!!, scenarioRun.workflowName!!)))
     return scenarioRun
   }
 

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/azure/ScenarioRunServiceImpl.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/azure/ScenarioRunServiceImpl.kt
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Service
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
 @Suppress("TooManyFunctions")
-class ScenarioRunServiceImpl(
+internal class ScenarioRunServiceImpl(
     private val workflowService: WorkflowService,
 ) : AbstractCosmosBackedService(), ScenariorunApiService {
 

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/container/SolutionContainerStepSpec.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/container/SolutionContainerStepSpec.kt
@@ -1,0 +1,14 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+package com.cosmotech.scenariorun.container
+
+import com.cosmotech.solution.domain.RunTemplate
+
+internal class SolutionContainerStepSpec(
+    val mode: String,
+    val providerVar: String,
+    val pathVar: String,
+    val source: ((template: RunTemplate) -> String?)? = null,
+    val path: ((organizationId: String, solutionId: String, runTemplateId: String) -> String)? =
+        null,
+)

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/container/StartInfo.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/container/StartInfo.kt
@@ -1,0 +1,18 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+package com.cosmotech.scenariorun.container
+
+import com.cosmotech.scenario.domain.Scenario
+import com.cosmotech.scenariorun.domain.ScenarioRunStartContainers
+import com.cosmotech.solution.domain.RunTemplate
+import com.cosmotech.solution.domain.Solution
+import com.cosmotech.workspace.domain.Workspace
+
+internal data class StartInfo(
+    val startContainers: ScenarioRunStartContainers,
+    val scenario: Scenario,
+    val workspace: Workspace,
+    val solution: Solution,
+    val runTemplate: RunTemplate,
+    val csmSimulationId: String,
+)

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/dataset/DatasetUtils.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/dataset/DatasetUtils.kt
@@ -1,0 +1,127 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+package com.cosmotech.scenariorun.dataset
+
+import com.cosmotech.api.config.CsmPlatformProperties
+import com.cosmotech.connector.api.ConnectorApiService
+import com.cosmotech.connector.domain.Connector
+import com.cosmotech.dataset.api.DatasetApiService
+import com.cosmotech.dataset.domain.Dataset
+import com.cosmotech.scenario.domain.Scenario
+import com.cosmotech.scenariorun.FETCH_PATH_VAR
+import com.cosmotech.scenariorun.getCommonEnvVars
+import com.cosmotech.scenariorun.resolvePlatformVars
+import com.cosmotech.solution.domain.RunTemplate
+import com.cosmotech.solution.domain.Solution
+
+internal const val PARAMETERS_DATASET_ID = "%DATASETID%"
+
+internal fun findDatasetsAndConnectors(
+    datasetService: DatasetApiService,
+    connectorService: ConnectorApiService,
+    organizationId: String,
+    scenario: Scenario,
+    solution: Solution,
+    runTemplate: RunTemplate
+): DatasetsConnectors {
+  val datasets: MutableMap<String, Dataset> = mutableMapOf()
+  val connectors: MutableMap<String, Connector> = mutableMapOf()
+  scenario.datasetList?.forEach { datasetId ->
+    addDatasetAndConnector(
+        datasetService, connectorService, organizationId, datasetId, datasets, connectors)
+  }
+  val parameterGroupIds = runTemplate.parameterGroups
+  if (parameterGroupIds != null) {
+    val parametersIds =
+        (solution.parameterGroups?.filter { it.id in parameterGroupIds }?.map { it.parameters })
+            ?.flatten()
+    if (parametersIds != null) {
+      solution
+          .parameters
+          ?.filter { it.id in parametersIds }
+          ?.filter { it.varType == PARAMETERS_DATASET_ID }
+          ?.forEach { parameter ->
+            val parameterValue = scenario.parametersValues?.find { it.parameterId == parameter.id }
+            if (parameterValue != null && parameterValue.value != "") {
+              addDatasetAndConnector(
+                  datasetService,
+                  connectorService,
+                  organizationId,
+                  parameterValue.value,
+                  datasets,
+                  connectors,
+              )
+            }
+          }
+    }
+  }
+  return DatasetsConnectors(
+      datasets = datasets.values.toList(), connectors = connectors.values.toList())
+}
+
+internal fun addDatasetAndConnector(
+    datasetService: DatasetApiService,
+    connectorService: ConnectorApiService,
+    organizationId: String,
+    datasetId: String,
+    datasets: MutableMap<String, Dataset>,
+    connectors: MutableMap<String, Connector>,
+) {
+  if (datasetId !in datasets) {
+    val dataset = datasetService.findDatasetById(organizationId, datasetId)
+    datasets[datasetId] = dataset
+    val connectorId =
+        dataset.connector?.id
+            ?: throw IllegalStateException("Connector Id for Dataset $datasetId is null")
+    if (connectorId !in connectors) {
+      val connector = connectorService.findConnectorById(connectorId)
+      connectors[connectorId] = connector
+    }
+  }
+}
+
+internal fun getDatasetEnvVars(
+    csmPlatformProperties: CsmPlatformProperties,
+    dataset: Dataset,
+    connector: Connector,
+    fetchPathBase: String,
+    fetchId: String?,
+    organizationId: String,
+    workspaceId: String,
+    workspaceKey: String,
+    csmSimulationId: String
+): Map<String, String> {
+  val envVars =
+      getCommonEnvVars(
+          csmPlatformProperties,
+          csmSimulationId,
+          organizationId,
+          workspaceKey,
+          azureManagedIdentity = connector.azureManagedIdentity,
+          azureAuthenticationWithCustomerAppRegistration =
+              connector.azureAuthenticationWithCustomerAppRegistration)
+  val fetchPath = if (fetchId == null) fetchPathBase else "${fetchPathBase}/${fetchId}"
+  envVars[FETCH_PATH_VAR] = fetchPath
+  val datasetEnvVars =
+      connector
+          .parameterGroups
+          ?.flatMap { it.parameters }
+          ?.filter { it.envVar != null }
+          ?.associateBy(
+              { it.envVar ?: "" },
+              {
+                resolvePlatformVars(
+                    csmPlatformProperties,
+                    dataset.connector?.parametersValues?.getOrDefault(it.id, it.default ?: "")
+                        ?: "",
+                    organizationId,
+                    workspaceId)
+              })
+  if (datasetEnvVars != null) envVars.putAll(datasetEnvVars)
+  return envVars
+}
+
+internal data class DatasetsConnectors(
+    val datasets: List<Dataset>,
+    val connectors: List<Connector>
+)

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/WorkflowService.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/WorkflowService.kt
@@ -8,7 +8,7 @@ import com.cosmotech.scenariorun.domain.ScenarioRunStartContainers
 import com.cosmotech.scenariorun.domain.ScenarioRunStatus
 import org.springframework.boot.actuate.health.HealthIndicator
 
-interface WorkflowService : HealthIndicator {
+internal interface WorkflowService : HealthIndicator {
 
   /**
    * Launch a new Scenario run, using the request specified

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/argo/ArgoWorkflowService.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/argo/ArgoWorkflowService.kt
@@ -390,6 +390,7 @@ internal class ArgoWorkflowService(
     else ""
   }
 
+  @Suppress("TooGenericExceptionCaught")
   override fun health(): Health {
     val healthBuilder =
         try {

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/argo/ArgoWorkflowService.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/argo/ArgoWorkflowService.kt
@@ -106,10 +106,6 @@ internal class ArgoWorkflowService(
         .build()
   }
 
-  private val artifactsService: ArgoArtifactsService by lazy {
-    this.unsafeScalarRetrofit.create(ArgoArtifactsService::class.java)
-  }
-
   private val artifactsByUidService: ArgoArtifactsByUidService by lazy {
     this.unsafeScalarRetrofit.create(ArgoArtifactsByUidService::class.java)
   }
@@ -123,9 +119,6 @@ internal class ArgoWorkflowService(
       setUserAgent("com.cosmotech/cosmotech-api $apiVersion")
     }
   }
-
-  private fun getLogArtifact(namespace: String, workflow: String, node: String, artifact: String) =
-      artifactsService.getArtifact(namespace, workflow, node, artifact).execute().body() ?: ""
 
   private fun getLogArtifactByUid(workflowId: String, node: String, artifact: String) =
       artifactsByUidService.getArtifactByUid(workflowId, node, artifact).execute().body() ?: ""

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/argo/ArgoWorkflowService.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/argo/ArgoWorkflowService.kt
@@ -154,10 +154,12 @@ internal class ArgoWorkflowService(
       val result =
           newServiceApiInstance<WorkflowServiceApi>()
               .workflowServiceCreateWorkflow(csmPlatformProperties.argo.workflows.namespace, body)
-      if (result.metadata.uid == null)
-          throw IllegalStateException("Argo Workflow metadata.uid is null")
-      if (result.metadata.name == null)
-          throw IllegalStateException("Argo Workflow metadata.name is null")
+      if (result.metadata.uid == null) {
+        throw IllegalStateException("Argo Workflow metadata.uid is null")
+      }
+      if (result.metadata.name == null) {
+        throw IllegalStateException("Argo Workflow metadata.name is null")
+      }
 
       return result
     } catch (e: ApiException) {

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/argo/WorkflowBuilders.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/argo/WorkflowBuilders.kt
@@ -53,6 +53,7 @@ internal fun buildTemplate(scenarioRunContainer: ScenarioRunContainer): Template
   val container =
       V1Container()
           .image(scenarioRunContainer.image)
+          .imagePullPolicy("Always")
           .env(envVars)
           .args(scenarioRunContainer.runArgs)
           .volumeMounts(volumeMounts)

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/argo/WorkflowBuilders.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/argo/WorkflowBuilders.kt
@@ -1,0 +1,141 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+package com.cosmotech.scenariorun.workflow.argo
+
+import com.cosmotech.api.config.CsmPlatformProperties
+import com.cosmotech.scenariorun.CSM_DAG_ROOT
+import com.cosmotech.scenariorun.domain.ScenarioRunContainer
+import com.cosmotech.scenariorun.domain.ScenarioRunStartContainers
+import io.argoproj.workflow.models.DAGTask
+import io.argoproj.workflow.models.DAGTemplate
+import io.argoproj.workflow.models.Metadata
+import io.argoproj.workflow.models.Template
+import io.argoproj.workflow.models.Workflow
+import io.argoproj.workflow.models.WorkflowSpec
+import io.kubernetes.client.custom.Quantity
+import io.kubernetes.client.openapi.models.V1Container
+import io.kubernetes.client.openapi.models.V1EnvVar
+import io.kubernetes.client.openapi.models.V1LocalObjectReference
+import io.kubernetes.client.openapi.models.V1ObjectMeta
+import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim
+import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimSpec
+import io.kubernetes.client.openapi.models.V1ResourceRequirements
+import io.kubernetes.client.openapi.models.V1VolumeMount
+
+private const val CSM_DAG_ENTRYPOINT = "entrypoint"
+private const val CSM_DEFAULT_WORKFLOW_NAME = "default-workflow-"
+internal const val VOLUME_CLAIM = "datadir"
+internal const val VOLUME_CLAIM_DATASETS_SUBPATH = "datasetsdir"
+internal const val VOLUME_CLAIM_PARAMETERS_SUBPATH = "parametersdir"
+private const val VOLUME_DATASETS_PATH = "/mnt/scenariorun-data"
+private const val VOLUME_PARAMETERS_PATH = "/mnt/scenariorun-parameters"
+
+internal fun buildTemplate(scenarioRunContainer: ScenarioRunContainer): Template {
+  var envVars: MutableList<V1EnvVar>? = null
+  if (scenarioRunContainer.envVars != null) {
+    envVars = mutableListOf()
+    scenarioRunContainer.envVars.forEach { (key, value) ->
+      val envVar = V1EnvVar().name(key).value(value)
+      envVars.add(envVar)
+    }
+  }
+  val volumeMounts =
+      listOf(
+          V1VolumeMount()
+              .name(VOLUME_CLAIM)
+              .mountPath(VOLUME_DATASETS_PATH)
+              .subPath(VOLUME_CLAIM_DATASETS_SUBPATH),
+          V1VolumeMount()
+              .name(VOLUME_CLAIM)
+              .mountPath(VOLUME_PARAMETERS_PATH)
+              .subPath(VOLUME_CLAIM_PARAMETERS_SUBPATH))
+
+  val container =
+      V1Container()
+          .image(scenarioRunContainer.image)
+          .env(envVars)
+          .args(scenarioRunContainer.runArgs)
+          .volumeMounts(volumeMounts)
+  if (scenarioRunContainer.entrypoint != null) {
+    container.command(listOf(scenarioRunContainer.entrypoint))
+  }
+
+  return Template()
+      .name(scenarioRunContainer.name)
+      .metadata(Metadata().labels(scenarioRunContainer.labels))
+      .container(container)
+}
+
+internal fun buildWorkflowSpec(
+    csmPlatformProperties: CsmPlatformProperties,
+    startContainers: ScenarioRunStartContainers
+): WorkflowSpec {
+  val nodeSelector = mutableMapOf("kubernetes.io/os" to "linux")
+  if (startContainers.nodeLabel != null) {
+    nodeSelector[csmPlatformProperties.argo.workflows.nodePoolLabel] = startContainers.nodeLabel
+  }
+  val templates =
+      startContainers.containers.map { container -> buildTemplate(container) }.toMutableList()
+  val entrypointTemplate = buildEntrypointTemplate(startContainers)
+  templates.add(entrypointTemplate)
+
+  return WorkflowSpec()
+      .imagePullSecrets(
+          csmPlatformProperties
+              .argo
+              .imagePullSecrets
+              ?.filterNot(String::isBlank)
+              ?.map(V1LocalObjectReference()::name)
+              ?.ifEmpty { null })
+      .nodeSelector(nodeSelector)
+      .serviceAccountName(csmPlatformProperties.argo.workflows.serviceAccountName)
+      .entrypoint(CSM_DAG_ENTRYPOINT)
+      .templates(templates)
+      .volumeClaimTemplates(buildVolumeClaims())
+}
+
+internal fun buildWorkflow(
+    csmPlatformProperties: CsmPlatformProperties,
+    startContainers: ScenarioRunStartContainers
+) =
+    Workflow()
+        .metadata(
+            V1ObjectMeta().generateName(startContainers.generateName ?: CSM_DEFAULT_WORKFLOW_NAME))
+        .spec(buildWorkflowSpec(csmPlatformProperties, startContainers))
+
+private fun buildEntrypointTemplate(startContainers: ScenarioRunStartContainers): Template {
+  val dagTemplate = Template().name(CSM_DAG_ENTRYPOINT)
+  val dagTasks: MutableList<DAGTask> = mutableListOf()
+  var previousContainer: ScenarioRunContainer? = null
+  for (container in startContainers.containers) {
+    var dependencies: List<String>? = null
+    if (container.dependencies != null) {
+      if (CSM_DAG_ROOT !in container.dependencies) {
+        dependencies = container.dependencies
+      }
+    } else {
+      if (previousContainer != null) dependencies = listOf(previousContainer.name)
+    }
+    val task = DAGTask().name(container.name).template(container.name).dependencies(dependencies)
+    dagTasks.add(task)
+    previousContainer = container
+  }
+
+  dagTemplate.dag(DAGTemplate().tasks(dagTasks))
+
+  return dagTemplate
+}
+
+private fun buildVolumeClaims(): List<V1PersistentVolumeClaim> {
+  // Azure file storage minimal claim is 100Gi for Premium classes
+  val dataDir =
+      V1PersistentVolumeClaim()
+          .metadata(V1ObjectMeta().name(VOLUME_CLAIM))
+          .spec(
+              V1PersistentVolumeClaimSpec()
+                  .accessModes(listOf("ReadWriteMany"))
+                  .storageClassName("phoenix-azurefile")
+                  .resources(
+                      V1ResourceRequirements().requests(mapOf("storage" to Quantity("100Gi")))))
+  return listOf(dataDir)
+}

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/argo/api/ArgoServerRetrofitServices.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/workflow/argo/api/ArgoServerRetrofitServices.kt
@@ -1,0 +1,26 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+package com.cosmotech.scenariorun.workflow.argo.api
+
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+internal interface ArgoArtifactsService {
+  @GET("artifacts/{namespace}/{workflow}/{node}/{artifact}")
+  fun getArtifact(
+      @Path("namespace") namespace: String,
+      @Path("workflow") workflow: String,
+      @Path("node") node: String,
+      @Path("artifact") artifact: String
+  ): Call<String>
+}
+
+internal interface ArgoArtifactsByUidService {
+  @GET("artifacts-by-uid/{uid}/{node}/{artifact}")
+  fun getArtifactByUid(
+      @Path("uid") uid: String,
+      @Path("node") node: String,
+      @Path("artifact") artifact: String
+  ): Call<String>
+}

--- a/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/ContainerFactoryTests.kt
+++ b/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/ContainerFactoryTests.kt
@@ -1047,7 +1047,7 @@ class ContainerFactoryTests {
             getOrganization(),
             solution,
             CSM_SIMULATION_ID)
-    assertEquals(containers.size, 1)
+    assertEquals(1, containers.size)
   }
 
   @Test

--- a/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/ContainerFactoryTests.kt
+++ b/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/ContainerFactoryTests.kt
@@ -18,6 +18,7 @@ import com.cosmotech.organization.domain.Organization
 import com.cosmotech.scenario.api.ScenarioApiService
 import com.cosmotech.scenario.domain.Scenario
 import com.cosmotech.scenario.domain.ScenarioRunTemplateParameterValue
+import com.cosmotech.scenariorun.container.StartInfo
 import com.cosmotech.scenariorun.domain.ScenarioRunContainer
 import com.cosmotech.solution.api.SolutionApiService
 import com.cosmotech.solution.domain.RunTemplate
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 private const val CSM_SIMULATION_ID = "simulationrunid"
 
+@Suppress("TooManyFunctions", "LargeClass")
 @ExtendWith(MockKExtension::class)
 class ContainerFactoryTests {
 
@@ -93,8 +95,7 @@ class ContainerFactoryTests {
         )
     every { azure.storage } returns
         CsmPlatformProperties.CsmPlatformAzure.CsmPlatformAzureStorage(
-            connectionString =
-                "DefaultEndpointsProtocol=https;AccountName=csmphoenix;AccountKey=42rmlBQ2IrxdIByLj79AecdIyYifSR04ZnGsBYt82tbM2clcP0QwJ9N+l/fLvyCzu9VZ8HPsQyM7jHe6CVSUig==;EndpointSuffix=core.windows.net",
+            connectionString = "csmphoenix_storage_connection_string",
             baseUri = "Not Used",
             resourceUri = "Not Used",
         )
@@ -274,8 +275,7 @@ class ContainerFactoryTests {
                 "https://ingest-phoenix.westeurope.kusto.windows.net",
             "AZURE_DATA_EXPLORER_DATABASE_NAME" to "Organizationid-Test",
             "CSM_FETCH_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
-            "AZURE_STORAGE_CONNECTION_STRING" to
-                "DefaultEndpointsProtocol=https;AccountName=csmphoenix;AccountKey=42rmlBQ2IrxdIByLj79AecdIyYifSR04ZnGsBYt82tbM2clcP0QwJ9N+l/fLvyCzu9VZ8HPsQyM7jHe6CVSUig==;EndpointSuffix=core.windows.net",
+            "AZURE_STORAGE_CONNECTION_STRING" to "csmphoenix_storage_connection_string",
         )
     assertEquals(expected, container.envVars)
   }
@@ -759,8 +759,7 @@ class ContainerFactoryTests {
                 "amqps://csm-phoenix.servicebus.windows.net/organizationid-test",
             "CSM_SIMULATION" to "TestSimulation",
             providerEnvVar to "azureStorage",
-            "AZURE_STORAGE_CONNECTION_STRING" to
-                "DefaultEndpointsProtocol=https;AccountName=csmphoenix;AccountKey=42rmlBQ2IrxdIByLj79AecdIyYifSR04ZnGsBYt82tbM2clcP0QwJ9N+l/fLvyCzu9VZ8HPsQyM7jHe6CVSUig==;EndpointSuffix=core.windows.net",
+            "AZURE_STORAGE_CONNECTION_STRING" to "csmphoenix_storage_connection_string",
             resourceEnvVar to "organizationid/1/${runTemplate}/${resource}.zip",
         )
     assertEquals(expected, container.envVars)
@@ -793,8 +792,7 @@ class ContainerFactoryTests {
                 "amqps://csm-phoenix.servicebus.windows.net/organizationid-test",
             "CSM_SIMULATION" to "TestSimulation",
             providerEnvVar to "local",
-            "AZURE_STORAGE_CONNECTION_STRING" to
-                "DefaultEndpointsProtocol=https;AccountName=csmphoenix;AccountKey=42rmlBQ2IrxdIByLj79AecdIyYifSR04ZnGsBYt82tbM2clcP0QwJ9N+l/fLvyCzu9VZ8HPsQyM7jHe6CVSUig==;EndpointSuffix=core.windows.net",
+            "AZURE_STORAGE_CONNECTION_STRING" to "csmphoenix_storage_connection_string",
         )
     assertEquals(expected, container.envVars)
   }
@@ -2006,18 +2004,6 @@ class ContainerFactoryTests {
                 solutionId = "1",
             ),
         sendInputToDataWarehouse = false,
-    )
-  }
-
-  private fun getWorkspaceNoDB(): Workspace {
-    return Workspace(
-        id = "workspaceid",
-        key = "Test",
-        name = "Test Workspace",
-        solution =
-            WorkspaceSolution(
-                solutionId = "1",
-            ),
     )
   }
 

--- a/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/ContainerFactoryTests.kt
+++ b/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/ContainerFactoryTests.kt
@@ -646,8 +646,7 @@ class ContainerFactoryTests {
             getSolutionLocalSources(),
             "testruntemplate",
             CSM_SIMULATION_ID)
-    envVarsWithSourceLocalValid(
-        container, "handle-parameters", "CSM_PARAMETERS_HANDLER_PROVIDER", "parameters_handler")
+    envVarsWithSourceLocalValid(container, "handle-parameters", "CSM_PARAMETERS_HANDLER_PROVIDER")
   }
 
   @Test
@@ -770,8 +769,7 @@ class ContainerFactoryTests {
   private fun envVarsWithSourceLocalValid(
       container: ScenarioRunContainer,
       mode: String,
-      providerEnvVar: String,
-      resource: String
+      providerEnvVar: String
   ) {
     val expected =
         mapOf(

--- a/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/workflow/argo/WorkflowBuildersTests.kt
+++ b/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/workflow/argo/WorkflowBuildersTests.kt
@@ -131,7 +131,7 @@ class WorkflowBuildersTests {
   fun `Create Workflow Spec with StartContainers agent pool`() {
     val workflows = mockk<CsmPlatformProperties.Argo.Workflows>(relaxed = true)
     every { workflows.nodePoolLabel } returns "agentpool"
-    val argo = mockk<CsmPlatformProperties.Argo>()
+    val argo = mockk<CsmPlatformProperties.Argo>(relaxed = true)
     every { argo.workflows } returns workflows
     every { csmPlatformProperties.argo } returns argo
 
@@ -146,7 +146,7 @@ class WorkflowBuildersTests {
   fun `Create Workflow Spec with StartContainers basic agent pool`() {
     val workflows = mockk<CsmPlatformProperties.Argo.Workflows>(relaxed = true)
     every { workflows.nodePoolLabel } returns "agentpool"
-    val argo = mockk<CsmPlatformProperties.Argo>()
+    val argo = mockk<CsmPlatformProperties.Argo>(relaxed = true)
     every { argo.workflows } returns workflows
     every { csmPlatformProperties.argo } returns argo
 
@@ -170,7 +170,7 @@ class WorkflowBuildersTests {
   fun `Create Workflow Spec with StartContainers Service Account`() {
     val workflows = mockk<CsmPlatformProperties.Argo.Workflows>(relaxed = true)
     every { workflows.serviceAccountName } returns "workflow"
-    val argo = mockk<CsmPlatformProperties.Argo>()
+    val argo = mockk<CsmPlatformProperties.Argo>(relaxed = true)
     every { argo.workflows } returns workflows
     every { csmPlatformProperties.argo } returns argo
 
@@ -220,7 +220,7 @@ class WorkflowBuildersTests {
   @Test
   fun `Create Workflow Spec with StartContainers entrypoint with dependencies dag valid`() {
     val sc = getStartContainersWithDependencies()
-    val workflowSpec = argoWorkflowService.buildWorkflowSpec(sc)
+    val workflowSpec = buildWorkflowSpec(csmPlatformProperties, sc)
 
     val entrypointTemplate =
         workflowSpec.templates?.find { template -> template.name.equals("entrypoint") }

--- a/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/workflow/argo/WorkflowBuildersTests.kt
+++ b/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/workflow/argo/WorkflowBuildersTests.kt
@@ -50,7 +50,7 @@ class WorkflowBuildersTests {
   @Test
   fun `Template has image pull policy set to Always`() {
     val src = getScenarioRunContainer()
-    val template = argoWorkflowService.buildTemplate(src)
+    val template = buildTemplate(src)
     assertNotNull(template.container)
     assertEquals("Always", template.container!!.imagePullPolicy)
   }

--- a/solution/src/main/kotlin/com/cosmotech/solution/azure/SolutionServiceImpl.kt
+++ b/solution/src/main/kotlin/com/cosmotech/solution/azure/SolutionServiceImpl.kt
@@ -33,7 +33,7 @@ import org.springframework.stereotype.Service
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
 @Suppress("TooManyFunctions")
-class SolutionServiceImpl(
+internal class SolutionServiceImpl(
     private val azureStorageBlobServiceClient: BlobServiceClient,
 ) : AbstractCosmosBackedService(), SolutionApiService {
 

--- a/solution/src/main/kotlin/com/cosmotech/solution/azure/SolutionServiceImpl.kt
+++ b/solution/src/main/kotlin/com/cosmotech/solution/azure/SolutionServiceImpl.kt
@@ -13,6 +13,7 @@ import com.cosmotech.api.events.OrganizationUnregistered
 import com.cosmotech.api.exceptions.CsmAccessForbiddenException
 import com.cosmotech.api.exceptions.CsmResourceNotFoundException
 import com.cosmotech.api.utils.changed
+import com.cosmotech.api.utils.compareToAndMutateIfNeeded
 import com.cosmotech.api.utils.getCurrentAuthenticatedUserName
 import com.cosmotech.solution.api.SolutionApiService
 import com.cosmotech.solution.domain.RunTemplate
@@ -165,7 +166,12 @@ class SolutionServiceImpl(
   ): Solution {
     val existingSolution = findSolutionById(organizationId, solutionId)
 
-    var hasChanged = false
+    // solutionId update is allowed but must be done with care. Maybe limit to minor update?
+    var hasChanged =
+        existingSolution
+            .compareToAndMutateIfNeeded(solution, excludedFields = arrayOf("ownerId"))
+            .isNotEmpty()
+
     if (solution.ownerId != null && solution.changed(existingSolution) { ownerId }) {
       // Allow to change the ownerId as well, but only the owner can transfer the ownership
       if (existingSolution.ownerId != getCurrentAuthenticatedUserName()) {
@@ -174,52 +180,6 @@ class SolutionServiceImpl(
             "You are not allowed to change the ownership of this Resource")
       }
       existingSolution.ownerId = solution.ownerId
-      hasChanged = true
-    }
-    if (solution.key != null && solution.changed(existingSolution) { key }) {
-      existingSolution.key = solution.key
-      hasChanged = true
-    }
-    if (solution.name != null && solution.changed(existingSolution) { name }) {
-      existingSolution.name = solution.name
-      hasChanged = true
-    }
-    if (solution.description != null && solution.changed(existingSolution) { description }) {
-      existingSolution.description = solution.description
-      hasChanged = true
-    }
-    if (solution.repository != null && solution.changed(existingSolution) { repository }) {
-      existingSolution.repository = solution.repository
-      hasChanged = true
-    }
-    // Solution update must be done with care. Maybe limit to minor update?
-    if (solution.version != null && solution.changed(existingSolution) { version }) {
-      existingSolution.version = solution.version
-      hasChanged = true
-    }
-
-    if (solution.url != null && solution.changed(existingSolution) { url }) {
-      existingSolution.url = solution.url
-      hasChanged = true
-    }
-
-    if (solution.tags != null && solution.tags?.toSet() != existingSolution.tags?.toSet()) {
-      existingSolution.tags = solution.tags
-      hasChanged = true
-    }
-
-    if (solution.parameters != null) {
-      existingSolution.parameters = solution.parameters
-      hasChanged = true
-    }
-
-    if (solution.parameterGroups != null) {
-      existingSolution.parameterGroups = solution.parameterGroups
-      hasChanged = true
-    }
-
-    if (solution.runTemplates != null) {
-      existingSolution.runTemplates = solution.runTemplates
       hasChanged = true
     }
 
@@ -243,101 +203,8 @@ class SolutionServiceImpl(
     }
     var hasChanged = false
     for (existingRunTemplate in runTemplates) {
-      if (runTemplate.name != null && runTemplate.changed(existingRunTemplate) { name }) {
-        existingRunTemplate.name = runTemplate.name
-        hasChanged = true
-      }
-      if (runTemplate.description != null &&
-          runTemplate.changed(existingRunTemplate) { description }) {
-        existingRunTemplate.description = runTemplate.description
-        hasChanged = true
-      }
-      if (runTemplate.tags != null &&
-          runTemplate.tags?.toSet() != existingRunTemplate.tags?.toSet()) {
-        existingRunTemplate.tags = runTemplate.tags
-        hasChanged = true
-      }
-      if (runTemplate.csmSimulation != null &&
-          runTemplate.changed(existingRunTemplate) { csmSimulation }) {
-        existingRunTemplate.csmSimulation = runTemplate.csmSimulation
-        hasChanged = true
-      }
-      if (runTemplate.computeSize != null &&
-          runTemplate.changed(existingRunTemplate) { computeSize }) {
-        existingRunTemplate.computeSize = runTemplate.computeSize
-        hasChanged = true
-      }
-      if (runTemplate.fetchDatasets != null &&
-          runTemplate.changed(existingRunTemplate) { fetchDatasets }) {
-        existingRunTemplate.fetchDatasets = runTemplate.fetchDatasets
-        hasChanged = true
-      }
-      if (runTemplate.fetchScenarioParameters != null &&
-          runTemplate.changed(existingRunTemplate) { fetchScenarioParameters }) {
-        existingRunTemplate.fetchScenarioParameters = runTemplate.fetchScenarioParameters
-        hasChanged = true
-      }
-      if (runTemplate.applyParameters != null &&
-          runTemplate.changed(existingRunTemplate) { applyParameters }) {
-        existingRunTemplate.applyParameters = runTemplate.applyParameters
-        hasChanged = true
-      }
-      if (runTemplate.validateData != null &&
-          runTemplate.changed(existingRunTemplate) { validateData }) {
-        existingRunTemplate.validateData = runTemplate.validateData
-        hasChanged = true
-      }
-      if (runTemplate.sendDatasetsToDataWarehouse != null &&
-          runTemplate.changed(existingRunTemplate) { sendDatasetsToDataWarehouse }) {
-        existingRunTemplate.sendDatasetsToDataWarehouse = runTemplate.sendDatasetsToDataWarehouse
-        hasChanged = true
-      }
-      if (runTemplate.sendInputParametersToDataWarehouse != null &&
-          runTemplate.changed(existingRunTemplate) { sendInputParametersToDataWarehouse }) {
-        existingRunTemplate.sendInputParametersToDataWarehouse =
-            runTemplate.sendInputParametersToDataWarehouse
-        hasChanged = true
-      }
-      if (runTemplate.preRun != null && runTemplate.changed(existingRunTemplate) { preRun }) {
-        existingRunTemplate.preRun = runTemplate.preRun
-        hasChanged = true
-      }
-      if (runTemplate.run != null && runTemplate.changed(existingRunTemplate) { run }) {
-        existingRunTemplate.run = runTemplate.run
-        hasChanged = true
-      }
-      if (runTemplate.postRun != null && runTemplate.changed(existingRunTemplate) { postRun }) {
-        existingRunTemplate.postRun = runTemplate.postRun
-        hasChanged = true
-      }
-      if (runTemplate.parametersHandlerSource != null &&
-          runTemplate.changed(existingRunTemplate) { parametersHandlerSource }) {
-        existingRunTemplate.parametersHandlerSource = runTemplate.parametersHandlerSource
-        hasChanged = true
-      }
-      if (runTemplate.datasetValidatorSource != null &&
-          runTemplate.changed(existingRunTemplate) { datasetValidatorSource }) {
-        existingRunTemplate.datasetValidatorSource = runTemplate.datasetValidatorSource
-        hasChanged = true
-      }
-      if (runTemplate.preRunSource != null &&
-          runTemplate.changed(existingRunTemplate) { preRunSource }) {
-        existingRunTemplate.preRunSource = runTemplate.preRunSource
-        hasChanged = true
-      }
-      if (runTemplate.runSource != null && runTemplate.changed(existingRunTemplate) { runSource }) {
-        existingRunTemplate.runSource = runTemplate.runSource
-        hasChanged = true
-      }
-      if (runTemplate.postRunSource != null && runTemplate.changed(existingRunTemplate) { name }) {
-        existingRunTemplate.name = runTemplate.name
-        hasChanged = true
-      }
-      if (runTemplate.parameterGroups != null &&
-          runTemplate.parameterGroups?.toSet() != existingRunTemplate.parameterGroups?.toSet()) {
-        existingRunTemplate.parameterGroups = runTemplate.parameterGroups
-        hasChanged = true
-      }
+      hasChanged =
+          hasChanged || existingRunTemplate.compareToAndMutateIfNeeded(runTemplate).isNotEmpty()
     }
 
     if (hasChanged) {

--- a/solution/src/main/kotlin/com/cosmotech/solution/azure/SolutionServiceImpl.kt
+++ b/solution/src/main/kotlin/com/cosmotech/solution/azure/SolutionServiceImpl.kt
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Service
 
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
+@Suppress("TooManyFunctions")
 class SolutionServiceImpl(
     private val azureStorageBlobServiceClient: BlobServiceClient,
 ) : AbstractCosmosBackedService(), SolutionApiService {

--- a/solution/src/main/kotlin/com/cosmotech/solution/utils/SolutionUtils.kt
+++ b/solution/src/main/kotlin/com/cosmotech/solution/utils/SolutionUtils.kt
@@ -10,6 +10,13 @@ fun getCloudPath(
     solutionId: String,
     runTemplateId: String,
     handlerId: RunTemplateHandlerId,
-): String {
-  return "${organizationId.sanitizeForAzureStorage()}/${solutionId.sanitizeForAzureStorage()}/${runTemplateId}/${handlerId}.zip"
-}
+) =
+    StringBuilder(organizationId.sanitizeForAzureStorage())
+        .append("/")
+        .append(solutionId.sanitizeForAzureStorage())
+        .append("/")
+        .append(runTemplateId)
+        .append("/")
+        .append(handlerId)
+        .append(".zip")
+        .toString()

--- a/user/src/main/kotlin/com/cosmotech/user/azure/UserServiceImpl.kt
+++ b/user/src/main/kotlin/com/cosmotech/user/azure/UserServiceImpl.kt
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Service
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
 @Suppress("TooManyFunctions")
-class UserServiceImpl : AbstractCosmosBackedService(), UserApiService {
+internal class UserServiceImpl : AbstractCosmosBackedService(), UserApiService {
 
   private lateinit var coreUserContainer: String
 

--- a/user/src/main/kotlin/com/cosmotech/user/azure/UserServiceImpl.kt
+++ b/user/src/main/kotlin/com/cosmotech/user/azure/UserServiceImpl.kt
@@ -26,6 +26,7 @@ import org.springframework.stereotype.Service
 
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
+@Suppress("TooManyFunctions")
 class UserServiceImpl : AbstractCosmosBackedService(), UserApiService {
 
   private lateinit var coreUserContainer: String

--- a/workspace/src/main/kotlin/com/cosmotech/workspace/azure/WorkspaceServiceImpl.kt
+++ b/workspace/src/main/kotlin/com/cosmotech/workspace/azure/WorkspaceServiceImpl.kt
@@ -126,13 +126,7 @@ class WorkspaceServiceImpl(
     workspace.users?.forEach { user ->
       this.eventPublisher.publishEvent(
           UserAddedToWorkspace(
-              this,
-              organizationId,
-              organization.name!!,
-              workspaceId,
-              workspace.name,
-              user.id!!,
-              user.roles.map { role -> role.value }))
+              this, organizationId, user.id!!, user.roles.map { role -> role.value }))
     }
     return workspaceUserWithRightNames
   }
@@ -236,13 +230,7 @@ class WorkspaceServiceImpl(
       workspace.users?.forEach { user ->
         this.eventPublisher.publishEvent(
             UserAddedToWorkspace(
-                this,
-                organizationId,
-                responseEntity.name!!,
-                workspaceId,
-                workspace.name,
-                user.id!!,
-                user.roles.map { role -> role.value }))
+                this, organizationId, user.id!!, user.roles.map { role -> role.value }))
       }
       responseEntity
     } else {

--- a/workspace/src/main/kotlin/com/cosmotech/workspace/azure/WorkspaceServiceImpl.kt
+++ b/workspace/src/main/kotlin/com/cosmotech/workspace/azure/WorkspaceServiceImpl.kt
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Service
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
 @Suppress("TooManyFunctions")
-class WorkspaceServiceImpl(
+internal class WorkspaceServiceImpl(
     private val resourceLoader: ResourceLoader,
     private val userService: UserApiService,
     private val organizationService: OrganizationApiService,

--- a/workspace/src/main/kotlin/com/cosmotech/workspace/azure/WorkspaceServiceImpl.kt
+++ b/workspace/src/main/kotlin/com/cosmotech/workspace/azure/WorkspaceServiceImpl.kt
@@ -40,6 +40,7 @@ import org.springframework.stereotype.Service
 
 @Service
 @ConditionalOnProperty(name = ["csm.platform.vendor"], havingValue = "azure", matchIfMissing = true)
+@Suppress("TooManyFunctions")
 class WorkspaceServiceImpl(
     private val resourceLoader: ResourceLoader,
     private val userService: UserApiService,


### PR DESCRIPTION
This fixes the long list of warnings reported by Detekt and visible in the GitHub Code Scanning results for this repo.

From now on, Detekt warnings will no longer be ignored by default.

**Commit Log**

- Reduce list of functions parameters
- Ignore warning about single class and file names not matching
- Ignore warning about performance penalty with the Spread Operator
- Fix magic number warning
- Fix warnings about way too long lines
- [scenariorun] Drop unused methods
- [scenariorun] Add missing parentheses around if statements
- [scenariorun] Suppress TooGenericExceptionCaught warning in ArgoWorkflowService#health()
- [scenariorun] Remove unused parameters
- [scenariorun] Fix ScenarioRunServiceImpl class name
- [scenariorun] Reduce visibility of some methods in ScenarioRunServiceImpl
- [common] Ignore UnnecessaryAbstractClass for AbstractCosmosBackedService.kt and AbstractCosmosBackedService.kt
- [api] Fix SpreadOperator performance warnings by passing a named parameter when needed
- refactor: Reflectively detect and update for simple generic changes
- chore: Fix few warnings reported by Detekt
- [scenariorun] Fix tests
- Review and adjust classes visibilities
