### PR TITLE
[PROD-7939] Handle scenario parent-child relationship upon deletion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -175,6 +175,7 @@ subprojects {
 
     testImplementation(kotlin("test"))
     testImplementation("io.mockk:mockk:1.12.0")
+    testImplementation("org.awaitility:awaitility-kotlin:4.1.0")
 
     integrationTestImplementation("org.springframework.boot:spring-boot-starter-test") {
       // Drop legacy Junit < 5

--- a/scenario/src/main/openapi/scenarios.yaml
+++ b/scenario/src/main/openapi/scenarios.yaml
@@ -202,6 +202,14 @@ paths:
           description: the Scenario specified is unknown or you don't have access to it
     delete:
       operationId: deleteScenario
+      parameters:
+        - name: wait_relationship_propagation
+          in: query
+          description: whether to wait until child scenarios are effectively updated
+          required: false
+          schema:
+            type: boolean
+            default: false
       tags:
         - scenario
       summary: Delete a scenario


### PR DESCRIPTION
## Requirements
https://spaceport.cosmotech.com/confluence/pages/viewpage.action?pageId=820936776#id-%F0%9F%94%A5WebApp-Scenariomanager-Deletesinglescenario

- when a non-master scenario is deleted, all its direct children scenarios need a new parent. The new parent will be the parent of the deleted scenario. For example, if we have `scenario1 → scenario2 → scenario3` and `scenario2` is deleted, the new tree is `scenario1 → scenario3`.
- when a master is deleted, all its direct children scenarios become master scenarios.

## Commit Log
- feat(PROD-7939): Add tests for scenario deletion requirements
- feat(PROD-7939): Introduce a new `wait_relationship_propagation` boolean query parameter to the `DELETE /organizations/:id/scenarios/:id` endpoint
- feat(PROD-7939): Assign a new parent to scenario children after their initial parent is dropped
