### PR TITLE
[PROD-8072] Pass Event Hub Shared Access Policy credentials to solution containers if told so

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -117,6 +117,16 @@ csm:
         solutions: ""
       eventBus:
         baseUri: ""
+        # One of 'tenant_client_credentials' or 'shared_access_policy'.
+        # Due to PROD-8071, shared_access_policy is needed when the platform is deployed in a tenant
+        # different from the core Platform one. This is applicable to managed applications
+        # provisioned via the Azure Marketplace
+        authentication:
+          strategy: tenant_client_credentials
+          sharedAccessPolicy:
+            namespace:
+              name: RootManageSharedAccessKey
+              key: null
       dataWarehouseCluster:
         baseUri: ""
         options:

--- a/common/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
+++ b/common/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
@@ -210,7 +210,32 @@ data class CsmPlatformProperties(
 
     data class CsmPlatformAzureContainerRegistries(val core: String, val solutions: String)
 
-    data class CsmPlatformAzureEventBus(val baseUri: String)
+    data class CsmPlatformAzureEventBus(
+        val baseUri: String,
+        val authentication: Authentication = Authentication()
+    ) {
+      data class Authentication(
+          val strategy: Strategy = Strategy.TENANT_CLIENT_CREDENTIALS,
+          val sharedAccessPolicy: SharedAccessPolicyDetails? = null,
+          val tenantClientCredentials: TenantClientCredentials? = null
+      ) {
+        enum class Strategy {
+          TENANT_CLIENT_CREDENTIALS,
+          SHARED_ACCESS_POLICY
+        }
+
+        data class SharedAccessPolicyDetails(
+            val namespace: SharedAccessPolicyCredentials? = null,
+        )
+
+        data class SharedAccessPolicyCredentials(val name: String, val key: String)
+        data class TenantClientCredentials(
+            val tenantId: String,
+            val clientId: String,
+            val clientSecret: String
+        )
+      }
+    }
 
     data class CsmPlatformAzureDataWarehouseCluster(val baseUri: String, val options: Options) {
       data class Options(val ingestionUri: String)


### PR DESCRIPTION
See [1] for the rationale.
Using the core App Registration tenant ID results in "Invalid Issuer"
errors reported by AMQP Consumers at simulation run time.
Using the customer tenant causes other issues as well, as described in
[1].
As a workaround, this adds the ability to authenticate using a configured shared access policy instead.
For now, we leverage the EventHub namespace RootManageSharedAccessKey, but it would ultimately be better to create and use a dedicated one.

[1] https://spaceport.cosmotech.com/jira/browse/PROD-8071