### PR TITLE
[PROD-8051] Add info about last runs of Parent and Root to a given child Scenario

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -176,6 +176,7 @@ subprojects {
     //    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
     testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.7.2")
     testImplementation("io.mockk:mockk:1.12.0")
     testImplementation("org.awaitility:awaitility-kotlin:4.1.0")
 

--- a/scenario/src/main/kotlin/com/cosmotech/scenario/azure/ScenarioExtensions.kt
+++ b/scenario/src/main/kotlin/com/cosmotech/scenario/azure/ScenarioExtensions.kt
@@ -1,0 +1,84 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+package com.cosmotech.scenario.azure
+
+import com.cosmotech.api.utils.convertToMap
+import com.cosmotech.scenario.domain.Scenario
+import org.slf4j.LoggerFactory
+
+internal fun Scenario.asMapWithAdditionalData(workspaceId: String): Map<String, Any> {
+  val scenarioAsMap = this.convertToMap().toMutableMap()
+  scenarioAsMap["type"] = "Scenario"
+  scenarioAsMap["workspaceId"] = workspaceId
+  return scenarioAsMap
+}
+
+// PROD-8051 : add parent and master last runs data
+internal fun Scenario.addLastRunsInfo(
+    scenarioServiceImpl: ScenarioServiceImpl,
+    organizationId: String,
+    workspaceId: String
+): Scenario {
+  val scenarioWithLastRunsInfo =
+      listOf(this).addLastRunsInfo(scenarioServiceImpl, organizationId, workspaceId).first()
+  this.parentLastRun = scenarioWithLastRunsInfo.parentLastRun
+  this.rootLastRun = scenarioWithLastRunsInfo.rootLastRun
+  return this
+}
+
+// Grouping for performance reasons. This allows to issue one call per parentId
+// and one call per rootId
+internal fun List<Scenario>.addLastRunsInfo(
+    scenarioServiceImpl: ScenarioServiceImpl,
+    organizationId: String,
+    workspaceId: String
+): List<Scenario> {
+  val logger =
+      LoggerFactory.getLogger("com.cosmotech.scenario.azure.ScenarioExtensions#addLastRunsInfo")
+  return this.groupBy { it.parentId }
+      .flatMap { (parentId, scenarios) ->
+        if (!parentId.isNullOrBlank()) {
+          val parentLastRun =
+              try {
+                scenarioServiceImpl.findScenarioByIdNoState(organizationId, workspaceId, parentId)
+                    .lastRun
+              } catch (iae: IllegalArgumentException) {
+                // There might be cases where the parent no longer exists
+                val messageFormat =
+                    "Parent scenario #{} not found " +
+                        "=> returning null as 'parentLastRun' " +
+                        "for all its {} direct child(ren)"
+                logger.debug(messageFormat, parentId, scenarios.size)
+                if (logger.isTraceEnabled) {
+                  logger.trace(messageFormat, parentId, scenarios.size, iae)
+                }
+                null
+              }
+          scenarios.forEach { it.parentLastRun = parentLastRun }
+        }
+        scenarios
+      }
+      .groupBy { it.rootId }
+      .flatMap { (rootId, scenarios) ->
+        if (!rootId.isNullOrBlank()) {
+          val rootLastRun =
+              try {
+                scenarioServiceImpl.findScenarioByIdNoState(organizationId, workspaceId, rootId)
+                    .lastRun
+              } catch (iae: IllegalArgumentException) {
+                // There might be cases where the root scenario no longer exists
+                val messageFormat =
+                    "Root scenario #{} not found" +
+                        "=> returning null as 'rootLastRun' " +
+                        "for all its {} child(ren)"
+                logger.debug(messageFormat, rootId, scenarios.size)
+                if (logger.isTraceEnabled) {
+                  logger.trace(messageFormat, rootId, scenarios.size, iae)
+                }
+                null
+              }
+          scenarios.forEach { it.rootLastRun = rootLastRun }
+        }
+        scenarios
+      }
+}

--- a/scenario/src/main/openapi/scenarios.yaml
+++ b/scenario/src/main/openapi/scenarios.yaml
@@ -534,24 +534,38 @@ components:
           items:
             $ref: '#/components/schemas/ScenarioRunTemplateParameterValue'
         lastRun:
-          type: object
-          description: the last Scenarion Run for this Scenario
-          properties:
-            scenarioRunId:
-              type: string
-              description: the last Scenario Run id
-            csmSimulationRun:
-              type: string
-              description: the last Cosmo Tech Simulation Run id
-            workflowId:
-              type: string
-              description: the last Workflow Id
-            workflowName:
-              type: string
-              description: the last Workflow name
+          allOf:
+            - $ref: '#/components/schemas/ScenarioLastRun'
+            - type: object
+              description: the last Scenario Run for this Scenario
+        parentLastRun:
+          allOf:
+            - $ref: '#/components/schemas/ScenarioLastRun'
+            - type: object
+              description: the last Scenario Run for the parent of this Scenario
+        rootLastRun:
+          allOf:
+            - $ref: '#/components/schemas/ScenarioLastRun'
+            - type: object
+              description: the last Scenario Run for the root (master) of Scenario
 #      required:
 #        - name
 #        - runTemplateId
+    ScenarioLastRun:
+      type: object
+      properties:
+        scenarioRunId:
+          type: string
+          description: the last Scenario Run id
+        csmSimulationRun:
+          type: string
+          description: the last Cosmo Tech Simulation Run id
+        workflowId:
+          type: string
+          description: the last Workflow Id
+        workflowName:
+          type: string
+          description: the last Workflow name
     ScenarioRunTemplateParameterValue:
       type: object
       description: the value of a Solution Run Template parameter for a Scenario


### PR DESCRIPTION
- [PROD-8051] Add new 'parentLastRun' and 'rootLastRun' fields to the Scenario API
- [PROD-8051] Add tests for this feature
- [PROD-8051] Make 'findAllScenarios' and 'findScenarioById' methods include info about parent and root last runs
