### PR TITLE
De-hardcode Workflows Persistent Volume Claims spec building

### DIFF
--- a/api/kubernetes/helm-chart/templates/_helpers.tpl
+++ b/api/kubernetes/helm-chart/templates/_helpers.tpl
@@ -139,8 +139,10 @@ csm:
       {{- else }}
       image-pull-secrets: []
       {{- end }}
+      {{- if .Values.argo.storage.class.install }}
       workflows:
         storage-class: {{ include "cosmotech-api.fullname" . }}-{{ .Release.Namespace }}
+      {{- end }}
     {{- if eq .Values.config.csm.platform.vendor "azure" }}
     azure:
       containerRegistries:

--- a/api/kubernetes/helm-chart/templates/storageclass.yaml
+++ b/api/kubernetes/helm-chart/templates/storageclass.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.argo.storage.class.install -}}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -11,3 +12,4 @@ parameters:
   {{- with .Values.argo.storage.class.parameters }}
     {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end }}

--- a/api/kubernetes/helm-chart/values-azure.yaml
+++ b/api/kubernetes/helm-chart/values-azure.yaml
@@ -37,9 +37,22 @@ resources:
 #    # az acr credential show -n csmengines --query="passwords[0].value" -o tsv
 #    password: "changeme"
 
+argo:
+  storage:
+    class:
+      install: true
+
 config:
   csm:
     platform:
+      argo:
+        workflows:
+          storage-class: null
+          access-modes:
+            - ReadWriteMany
+          requests:
+            # Azure file storage minimal claim is 100Gi for Premium classes
+            storage: 100Gi
       azure:
         credentials:
           # TODO Breaking change: Move deprecated tenantId, clientId and clientSecret under the new 'core' field

--- a/api/kubernetes/helm-chart/values-dev.yaml
+++ b/api/kubernetes/helm-chart/values-dev.yaml
@@ -22,6 +22,11 @@ ingress:
   hosts:
     - host: localhost
 
+argo:
+  storage:
+    class:
+      install: false
+
 config:
   logging:
     level:
@@ -29,6 +34,16 @@ config:
       com.cosmotech: DEBUG
   csm:
     platform:
+      argo:
+        workflows:
+          # Use any default storage class available
+          storage-class: null
+          access-modes:
+            # ReadWriteMany is recommended, as we are likely to have parallel pods accessing the volume.
+            # But this is not possible locally for now. See PROD-8043
+            - ReadWriteOnce
+          requests:
+            storage: 1Gi
       azure:
         credentials:
           # TODO Breaking change: Move deprecated tenantId, clientId and clientSecret under the new 'core' field

--- a/api/kubernetes/helm-chart/values.yaml
+++ b/api/kubernetes/helm-chart/values.yaml
@@ -129,6 +129,8 @@ argo:
   storage:
     # -- storage class used by Workflows submitted to Argo
     class:
+      # -- whether to install the storage class
+      install: true
       # -- volume plugin used for provisioning Persistent Volumes
       provisioner: kubernetes.io/azure-file
       # -- mount options, depending on the volume plugin configured. If the volume plugin does not support mount options but mount options are specified, provisioning will fail.
@@ -151,7 +153,17 @@ config:
       argo:
         base-uri: "http://argo-server:2746"
         workflows:
-          storage-class: "phoenix-azurefile"
+          # -- Name of the storage class for Workflows volumes.
+          # Useful if you want to use a different storage class, installed and managed externally.
+          # In this case, you should set argo.storage.class.install to false.
+          storage-class: null
+          access-modes:
+            # -- Any in the following list: ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod (K8s 1.22+).
+            # ReadWriteMany is recommended, as we are likely to have parallel pods accessing the volume
+            - ReadWriteMany
+          requests:
+            # Azure file storage minimal claim is 100Gi for Premium classes
+            storage: 100Gi
       authorization:
         allowed-tenants: []
       azure:

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -74,7 +74,12 @@ csm:
         namespace: phoenix
         node-pool-label: agentpool
         service-account-name: workflow
-        storage-class: "phoenix-azurefile"
+        storage-class: null
+        access-modes:
+          # Any in the following list: ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod (K8s 1.22+)
+          - ReadWriteOnce
+        requests:
+          storage: 1Gi
     images:
       scenario-fetch-parameters: cosmo-tech/fetch-scenario-parameters
       send-datawarehouse: cosmo-tech/azure-data-explorer-connector

--- a/common/common/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
+++ b/common/common/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
@@ -94,8 +94,20 @@ data class CsmPlatformProperties(
         /** The Kubernetes service account name */
         val serviceAccountName: String,
 
-        /** The Kubernetes storage-class to use for volume claims */
-        val storageClass: String,
+        /**
+         * The Kubernetes storage-class to use for volume claims. Set to null or an empty string to
+         * use the default storage class available in the cluster
+         */
+        val storageClass: String? = null,
+
+        /** List of AccessModes for the Kubernetes Persistent Volume Claims to use for Workflows */
+        val accessModes: List<String> = emptyList(),
+
+        /**
+         * Minimum resources the volumes requested by the Persistent Volume Claims should have.
+         * Example: storage: 1Gi
+         */
+        val requests: Map<String, String> = emptyMap(),
     )
   }
 

--- a/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/workflow/argo/WorkflowBuildersTests.kt
+++ b/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/workflow/argo/WorkflowBuildersTests.kt
@@ -373,9 +373,27 @@ class WorkflowBuildersTests {
   }
 
   @Test
+  fun `Create Workflow spec with StartContainers volume claim default values`() {
+    val sc = getStartContainersDiamond()
+    val workflowSpec = buildWorkflowSpec(csmPlatformProperties, sc)
+    val dataDir =
+        V1PersistentVolumeClaim()
+            .metadata(V1ObjectMeta().name(VOLUME_CLAIM))
+            .spec(
+                V1PersistentVolumeClaimSpec()
+                    .accessModes(emptyList())
+                    .storageClassName(null)
+                    .resources(V1ResourceRequirements().requests(emptyMap())))
+    val expected = listOf(dataDir)
+    assertEquals(expected, workflowSpec.volumeClaimTemplates)
+  }
+
+  @Test
   fun `Create Workflow spec with StartContainers volume claim`() {
     val sc = getStartContainersDiamond()
     every { csmPlatformProperties.argo.workflows.storageClass } returns "cosmotech-api-test-phoenix"
+    every { csmPlatformProperties.argo.workflows.accessModes } returns listOf("ReadWriteMany")
+    every { csmPlatformProperties.argo.workflows.requests } returns mapOf("storage" to "300Gi")
     val workflowSpec = buildWorkflowSpec(csmPlatformProperties, sc)
     val dataDir =
         V1PersistentVolumeClaim()
@@ -385,7 +403,7 @@ class WorkflowBuildersTests {
                     .accessModes(listOf("ReadWriteMany"))
                     .storageClassName("cosmotech-api-test-phoenix")
                     .resources(
-                        V1ResourceRequirements().requests(mapOf("storage" to Quantity("100Gi")))))
+                        V1ResourceRequirements().requests(mapOf("storage" to Quantity("300Gi")))))
     val expected = listOf(dataDir)
     assertEquals(expected, workflowSpec.volumeClaimTemplates)
   }


### PR DESCRIPTION
At this time, running a ScenarioRun in a local cluster requires manual changes
to `WorkflowBuilders.kt`, like changing the storage class and storage request
for PVCs used by the ScenarioRun Workflows.
This makes the development experience unpractical.

The changes here make the PVCs options configurable, with sensible defaults
that are backward-compatible.
This is anyway a preliminary step for PROD-8043, which aims at ultimately
being able to specify a local storage class with `ReadWriteMany` access mode
capabilities.