### PR TITLE
Bump Kotlin from 1.5.31 to 1.6.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 import pl.allegro.tech.build.axion.release.domain.TagNameSerializationConfig
 
 plugins {
-  val kotlinVersion = "1.5.31"
+  val kotlinVersion = "1.6.0"
   kotlin("jvm") version kotlinVersion
   kotlin("plugin.spring") version kotlinVersion apply false
   id("pl.allegro.tech.build.axion-release") version "1.13.6"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,12 +69,12 @@ allprojects {
       licenseHeader(licenseHeaderComment)
     }
     kotlin {
-      ktfmt()
+      ktfmt("0.30")
       target("**/*.kt")
       licenseHeader(licenseHeaderComment)
     }
     kotlinGradle {
-      ktfmt()
+      ktfmt("0.30")
       target("**/*.kts")
       //      licenseHeader(licenseHeaderComment, "import")
     }


### PR DESCRIPTION
There is an issue preventing from running Spotless under Kotlin 1.6.0﻿.
This has been reported in facebookincubator/ktfmt#259.
So we have to wait until this is fixed first.
