### PR TITLE
Fix sent messages total when multiple simulations prod 8906

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -161,18 +161,13 @@ csm:
       # Number of seconds to wait after a scenario run workflow end time, before
       # starting to check ADX for data ingestion state.
       # See https://bit.ly/3FXshzE for the rationale
-      waiting-time-before-ingestion-seconds: 10
+      waiting-time-before-ingestion-seconds: 15
       # number of minutes after a scenario run workflow end time during which an ingestion failure
       # detected is considered linked to the current scenario run
       ingestion-observation-window-to-be-considered-a-failure-minutes: 5
       state:
-        # state to report if there no ingestion failure detected, and no control plane info,
-        # but we have probe measures in ADX.
-        # Value should be convertible to a DataIngestionState
-        # (e.g., InProgress, Successful, Failure, Unknown)
-        state-if-no-control-plane-info-but-probe-measures-data: Successful
-        # whether to report an error if there is neither control plane info nor probe measures data in ADX
-        exception-if-no-control-plane-info-and-no-probe-measures-data: true
+        # the timeout in second before considering no data in probes measures and control plane is an issue
+        no-data-time-out-seconds: 60
 
 springdoc:
   # See https://springdoc.org/#properties

--- a/common/common/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
+++ b/common/common/src/main/kotlin/com/cosmotech/api/config/CsmPlatformProperties.kt
@@ -329,7 +329,7 @@ data class CsmPlatformProperties(
        * Number of seconds to wait after a scenario run workflow end time, before starting to check
        * ADX for data ingestion state. See https://bit.ly/3FXshzE for the rationale
        */
-      val waitingTimeBeforeIngestionSeconds: Long = 10,
+      val waitingTimeBeforeIngestionSeconds: Long = 15,
 
       /**
        * number of minutes after a scenario run workflow end time during which an ingestion failure
@@ -342,17 +342,10 @@ data class CsmPlatformProperties(
   ) {
     data class State(
         /**
-         * Whether to throw an exception if we have no control plane info about the scenario run,
-         * and no probe measures data. This may typically happen if the simulation has no consumers.
+         * The timeout in second before considering no data in probes measures and control plane is
+         * an issue
          */
-        val exceptionIfNoControlPlaneInfoAndNoProbeMeasuresData: Boolean = true,
-
-        /**
-         * State to report if we have no ingestion failure, and no control plane info about the
-         * scenario run, but we have probe measures data. One of Successful, InProgress, Failure,
-         * Unknown
-         */
-        val stateIfNoControlPlaneInfoButProbeMeasuresData: String = "Successful",
+        val noDataTimeOutSeconds: Long = 60,
     )
   }
 }

--- a/doc/Models/RunTemplate.md
+++ b/doc/Models/RunTemplate.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **csmSimulation** | **String** | the Cosmo Tech simulation name. This information is send to the Engine. Mandatory information if no Engine is defined | [optional] [default to null]
 **tags** | **List** | the list of Run Template tags | [optional] [default to null]
 **computeSize** | **String** | the compute size needed for this Run Template. Standard sizes are basic and highcpu. Default is basic | [optional] [default to null]
+**noDatawarehouseConsumers** | **Boolean** | set to true if the simulation does not use any Datawarehouse consumers (AMQP consumers for Azure) | [optional] [default to null]
 **fetchDatasets** | **Boolean** | whether or not the fetch dataset step is done | [optional] [default to null]
 **scenarioDataDownloadTransform** | **Boolean** | whether or not the scenario data download transform step step is done | [optional] [default to null]
 **fetchScenarioParameters** | **Boolean** | whether or not the fetch parameters step is done | [optional] [default to null]

--- a/doc/Models/RunTemplate.md
+++ b/doc/Models/RunTemplate.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **csmSimulation** | **String** | the Cosmo Tech simulation name. This information is send to the Engine. Mandatory information if no Engine is defined | [optional] [default to null]
 **tags** | **List** | the list of Run Template tags | [optional] [default to null]
 **computeSize** | **String** | the compute size needed for this Run Template. Standard sizes are basic and highcpu. Default is basic | [optional] [default to null]
-**noDatawarehouseConsumers** | **Boolean** | set to true if the simulation does not use any Datawarehouse consumers (AMQP consumers for Azure) | [optional] [default to null]
+**noDataIngestionState** | **Boolean** | set to true if the run template does not want to check data ingestion state (no probes or not control plane) | [optional] [default to null]
 **fetchDatasets** | **Boolean** | whether or not the fetch dataset step is done | [optional] [default to null]
 **scenarioDataDownloadTransform** | **Boolean** | whether or not the scenario data download transform step step is done | [optional] [default to null]
 **fetchScenarioParameters** | **Boolean** | whether or not the fetch parameters step is done | [optional] [default to null]

--- a/doc/Models/ScenarioRun.md
+++ b/doc/Models/ScenarioRun.md
@@ -17,6 +17,8 @@ Name | Type | Description | Notes
 **solutionId** | **String** | the Solution Id | [optional] [default to null]
 **runTemplateId** | **String** | the Solution Run Template id | [optional] [default to null]
 **computeSize** | **String** | the compute size needed for this Analysis. Standard sizes are basic and highcpu. Default is basic | [optional] [default to null]
+**sdkVersion** | **String** | the MAJOR.MINOR version used to build the solution solution | [optional] [default to null]
+**noDataIngestionState** | **Boolean** | set to true if the run template does not use any Datawarehouse consumers (AMQP consumers for Azure) | [optional] [default to null]
 **datasetList** | **List** | the list of Dataset Id associated to this Analysis | [optional] [default to null]
 **parametersValues** | [**List**](RunTemplateParameterValue.md) | the list of Run Template parameters values | [optional] [default to null]
 **sendDatasetsToDataWarehouse** | **Boolean** | whether or not the Datasets values are send to the DataWarehouse prior to Simulation Run. If not set follow the Workspace setting | [optional] [default to null]

--- a/doc/Models/Solution.md
+++ b/doc/Models/Solution.md
@@ -11,6 +11,7 @@ Name | Type | Description | Notes
 **csmSimulator** | **String** | the main Cosmo Tech simulator name used in standard Run Template | [optional] [default to null]
 **version** | **String** | the Solution version MAJOR.MINOR.PATCH. Must be aligned with an existing repository tag | [default to null]
 **ownerId** | **String** | the User id which own this Solution | [optional] [default to null]
+**sdkVersion** | **String** | the MAJOR.MINOR version used to build this solution | [optional] [default to null]
 **url** | **String** | an optional URL link to solution page | [optional] [default to null]
 **tags** | **List** | the list of tags | [optional] [default to null]
 **parameters** | [**List**](RunTemplateParameter.md) | the list of Run Template Parameters | [optional] [default to null]

--- a/openapi/plantuml/schemas.plantuml
+++ b/openapi/plantuml/schemas.plantuml
@@ -103,7 +103,7 @@ entity RunTemplate {
     csmSimulation: String
     tags: List<String>
     computeSize: String
-    noDatawarehouseConsumers: Boolean
+    noDataIngestionState: Boolean
     fetchDatasets: Boolean
     scenarioDataDownloadTransform: Boolean
     fetchScenarioParameters: Boolean
@@ -229,6 +229,8 @@ entity ScenarioRun {
     solutionId: String
     runTemplateId: String
     computeSize: String
+    sdkVersion: String
+    noDataIngestionState: Boolean
     datasetList: List<String>
     parametersValues: List<RunTemplateParameterValue>
     sendDatasetsToDataWarehouse: Boolean
@@ -339,6 +341,7 @@ entity Solution {
     csmSimulator: String
     * version: String
     ownerId: String
+    sdkVersion: String
     url: String
     tags: List<String>
     parameters: List<RunTemplateParameter>

--- a/openapi/plantuml/schemas.plantuml
+++ b/openapi/plantuml/schemas.plantuml
@@ -103,6 +103,7 @@ entity RunTemplate {
     csmSimulation: String
     tags: List<String>
     computeSize: String
+    noDatawarehouseConsumers: Boolean
     fetchDatasets: Boolean
     scenarioDataDownloadTransform: Boolean
     fetchScenarioParameters: Boolean

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/azure/ScenarioRunServiceImpl.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/azure/ScenarioRunServiceImpl.kt
@@ -409,7 +409,7 @@ internal class ScenarioRunServiceImpl(
             runTemplateId = runTemplate?.id,
             generateName = startContainers.generateName,
             computeSize = runTemplate?.computeSize,
-            noDatawarehouseConsumers = runTemplate?.noDatawarehouseConsumers,
+            noDataIngestionState = runTemplate?.noDataIngestionState,
             sdkVersion = solution?.sdkVersion,
             datasetList = scenario?.datasetList,
             parametersValues =
@@ -482,10 +482,11 @@ internal class ScenarioRunServiceImpl(
                 // CSM_CONTROL_PLANE_TOPIC variable is present in any of the containers
                 // And if the run template send data to datawarehouse with probe consumers
                 checkDataIngestionState =
-                    scenarioRun.containers?.any {
+                    (scenarioRun.containers?.any {
                       !it.envVars?.get(EVENT_HUB_CONTROL_PLANE_VAR).isNullOrBlank()
-                    } &&
-                        !(scenarioRun.noDatawarehouseConsumers ?: false) &&
+                    }
+                        ?: false) &&
+                        !(scenarioRun.noDataIngestionState ?: false) &&
                         versionWithDataIngestionState))
   }
 

--- a/scenariorun/src/main/openapi/scenariorun.yaml
+++ b/scenariorun/src/main/openapi/scenariorun.yaml
@@ -573,6 +573,9 @@ components:
           type: string
           readOnly: true
           description: the compute size needed for this Analysis. Standard sizes are basic and highcpu. Default is basic
+        noDatawarehouseConsumers:
+          type: boolean
+          description: set to true if the simulation does not use any Datawarehouse consumers (AMQP consumers for Azure)
         datasetList:
           type: array
           readOnly: true

--- a/scenariorun/src/main/openapi/scenariorun.yaml
+++ b/scenariorun/src/main/openapi/scenariorun.yaml
@@ -573,9 +573,12 @@ components:
           type: string
           readOnly: true
           description: the compute size needed for this Analysis. Standard sizes are basic and highcpu. Default is basic
-        noDatawarehouseConsumers:
+        sdkVersion:
+          type: string
+          description: the MAJOR.MINOR version used to build the solution solution
+        noDataIngestionState:
           type: boolean
-          description: set to true if the simulation does not use any Datawarehouse consumers (AMQP consumers for Azure)
+          description: set to true if the run template does not use any Datawarehouse consumers (AMQP consumers for Azure)
         datasetList:
           type: array
           readOnly: true

--- a/solution/src/main/openapi/solution.yaml
+++ b/solution/src/main/openapi/solution.yaml
@@ -563,9 +563,9 @@ components:
         computeSize:
           type: string
           description: the compute size needed for this Run Template. Standard sizes are basic and highcpu. Default is basic
-        noDatawarehouseConsumers:
+        noDataIngestionState:
           type: boolean
-          description: set to true if the simulation does not use any Datawarehouse consumers (AMQP consumers for Azure)
+          description: set to true if the run template does not want to check data ingestion state (no probes or not control plane)
         fetchDatasets:
           type: boolean
           description: whether or not the fetch dataset step is done

--- a/solution/src/main/openapi/solution.yaml
+++ b/solution/src/main/openapi/solution.yaml
@@ -507,6 +507,9 @@ components:
           type: string
           readOnly: true
           description: the User id which own this Solution
+        sdkVersion:
+          type: string
+          description: the MAJOR.MINOR version used to build this solution
         url:
           type: string
           description: an optional URL link to solution page
@@ -560,6 +563,9 @@ components:
         computeSize:
           type: string
           description: the compute size needed for this Run Template. Standard sizes are basic and highcpu. Default is basic
+        noDatawarehouseConsumers:
+          type: boolean
+          description: set to true if the simulation does not use any Datawarehouse consumers (AMQP consumers for Azure)
         fetchDatasets:
           type: boolean
           description: whether or not the fetch dataset step is done


### PR DESCRIPTION
Fix sent messages total when multiple simulations + Race condition on simulation total facts calls:
* noDataTimeOutSeconds API option
* solution.sdkVersion
* runtemplate.noDataIngestionState