### PR TITLE
Updated default sizing informations for pods

### DIFF
--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/container/StartInfo.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/container/StartInfo.kt
@@ -34,18 +34,18 @@ fun Sizing.toContainerResourceSizing(): ContainerResourceSizing {
 
 internal val BASIC_SIZING =
     Sizing(
-        requests = SizingInfo(cpu = "1", memory = "6Gi"),
-        limits = SizingInfo(cpu = "4", memory = "6Gi"))
+        requests = SizingInfo(cpu = "3", memory = "4Gi"),
+        limits = SizingInfo(cpu = "3", memory = "4Gi"))
 
 internal val HIGH_MEMORY_SIZING =
     Sizing(
-        requests = SizingInfo(cpu = "1", memory = "32Gi"),
-        limits = SizingInfo(cpu = "16", memory = "64Gi"))
+        requests = SizingInfo(cpu = "7", memory = "57Gi"),
+        limits = SizingInfo(cpu = "7", memory = "57Gi"))
 
 internal val HIGH_CPU_SIZING =
     Sizing(
-        requests = SizingInfo(cpu = "24", memory = "48Gi"),
-        limits = SizingInfo(cpu = "72", memory = "144Gi"))
+        requests = SizingInfo(cpu = "70", memory = "130Gi"),
+        limits = SizingInfo(cpu = "70", memory = "130Gi"))
 
 fun ScenarioResourceSizing.toSizing(): Sizing {
   return Sizing(

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/container/StartInfo.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/container/StartInfo.kt
@@ -34,18 +34,18 @@ fun Sizing.toContainerResourceSizing(): ContainerResourceSizing {
 
 internal val BASIC_SIZING =
     Sizing(
-        requests = SizingInfo(cpu = "1", memory = "64Mi"),
-        limits = SizingInfo(cpu = "4", memory = "6144Mi"))
+        requests = SizingInfo(cpu = "1", memory = "4Gi"),
+        limits = SizingInfo(cpu = "4", memory = "4Gi"))
 
 internal val HIGH_MEMORY_SIZING =
     Sizing(
-        requests = SizingInfo(cpu = "1", memory = "64000Mi"),
-        limits = SizingInfo(cpu = "16", memory = "128000Mi"))
+        requests = SizingInfo(cpu = "1", memory = "32Gi"),
+        limits = SizingInfo(cpu = "16", memory = "64Gi"))
 
 internal val HIGH_CPU_SIZING =
     Sizing(
-        requests = SizingInfo(cpu = "24", memory = "4096Mi"),
-        limits = SizingInfo(cpu = "72", memory = "144000Mi"))
+        requests = SizingInfo(cpu = "24", memory = "48Gi"),
+        limits = SizingInfo(cpu = "72", memory = "144Gi"))
 
 fun ScenarioResourceSizing.toSizing(): Sizing {
   return Sizing(

--- a/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/container/StartInfo.kt
+++ b/scenariorun/src/main/kotlin/com/cosmotech/scenariorun/container/StartInfo.kt
@@ -34,8 +34,8 @@ fun Sizing.toContainerResourceSizing(): ContainerResourceSizing {
 
 internal val BASIC_SIZING =
     Sizing(
-        requests = SizingInfo(cpu = "1", memory = "4Gi"),
-        limits = SizingInfo(cpu = "4", memory = "4Gi"))
+        requests = SizingInfo(cpu = "1", memory = "6Gi"),
+        limits = SizingInfo(cpu = "4", memory = "6Gi"))
 
 internal val HIGH_MEMORY_SIZING =
     Sizing(


### PR DESCRIPTION
Basic sizing for pods being extremely different between request and limits allowed for strange edge cases, so this PR reduce the difference between those ensuring lower risks during execution.