### PR TITLE
Add new orchestrator type to Run Templates

### DIFF
--- a/doc/.openapi-generator/FILES
+++ b/doc/.openapi-generator/FILES
@@ -29,6 +29,7 @@ Models/OrganizationServices.md
 Models/ResourceSizeInfo.md
 Models/RunTemplate.md
 Models/RunTemplateHandlerId.md
+Models/RunTemplateOrchestrator.md
 Models/RunTemplateParameter.md
 Models/RunTemplateParameterGroup.md
 Models/RunTemplateParameterValue.md

--- a/doc/Models/RunTemplate.md
+++ b/doc/Models/RunTemplate.md
@@ -33,6 +33,7 @@ Name | Type | Description | Notes
 **gitRepositoryUrl** | **String** | an optional URL to the git repository | [optional] [default to null]
 **gitBranchName** | **String** | an optional git branch name | [optional] [default to null]
 **runTemplateSourceDir** | **String** | an optional directory where to find the run template source | [optional] [default to null]
+**orchestratorType** | [**RunTemplateOrchestrator**](RunTemplateOrchestrator.md) |  | [optional] [default to null]
 **executionTimeout** | **Integer** | an optional duration in seconds in which a workflow is allowed to run | [optional] [default to null]
 **deleteHistoricalData** | [**DeleteHistoricalData**](DeleteHistoricalData.md) |  | [optional] [default to null]
 

--- a/doc/Models/RunTemplateOrchestrator.md
+++ b/doc/Models/RunTemplateOrchestrator.md
@@ -1,0 +1,8 @@
+# RunTemplateOrchestrator
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/doc/README.md
+++ b/doc/README.md
@@ -165,6 +165,7 @@ Class | Method | HTTP request | Description
  - [ResourceSizeInfo](./Models/ResourceSizeInfo.md)
  - [RunTemplate](./Models/RunTemplate.md)
  - [RunTemplateHandlerId](./Models/RunTemplateHandlerId.md)
+ - [RunTemplateOrchestrator](./Models/RunTemplateOrchestrator.md)
  - [RunTemplateParameter](./Models/RunTemplateParameter.md)
  - [RunTemplateParameterGroup](./Models/RunTemplateParameterGroup.md)
  - [RunTemplateParameterValue](./Models/RunTemplateParameterValue.md)

--- a/openapi/plantuml/schemas.plantuml
+++ b/openapi/plantuml/schemas.plantuml
@@ -170,11 +170,15 @@ entity RunTemplate {
     gitRepositoryUrl: String
     gitBranchName: String
     runTemplateSourceDir: String
+    orchestratorType: RunTemplateOrchestrator
     executionTimeout: Integer
     deleteHistoricalData: DeleteHistoricalData
 }
 
 entity RunTemplateHandlerId {
+}
+
+entity RunTemplateOrchestrator {
 }
 
 entity RunTemplateParameter {

--- a/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/ContainerFactoryTests.kt
+++ b/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/ContainerFactoryTests.kt
@@ -32,6 +32,7 @@ import com.cosmotech.scenariorun.container.StartInfo
 import com.cosmotech.scenariorun.domain.ScenarioRunContainer
 import com.cosmotech.solution.api.SolutionApiService
 import com.cosmotech.solution.domain.RunTemplate
+import com.cosmotech.solution.domain.RunTemplateOrchestrator
 import com.cosmotech.solution.domain.RunTemplateParameter
 import com.cosmotech.solution.domain.RunTemplateParameterGroup
 import com.cosmotech.solution.domain.RunTemplateStepSource
@@ -1084,7 +1085,8 @@ class ContainerFactoryTests {
             "TWIN_CACHE_HOST" to "this_is_a_host",
             "TWIN_CACHE_PORT" to "6973",
             "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default")
+            "TWIN_CACHE_USERNAME" to "default",
+            "CSM_ENTRYPOINT_LEGACY" to "true")
     assertEquals(expected.toSortedMap(), container.envVars?.toSortedMap())
   }
 
@@ -1123,10 +1125,10 @@ class ContainerFactoryTests {
             "TWIN_CACHE_HOST" to "this_is_a_host",
             "TWIN_CACHE_PORT" to "6973",
             "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default")
+            "TWIN_CACHE_USERNAME" to "default",
+            "CSM_ENTRYPOINT_LEGACY" to "true")
     assertEquals(expected.toSortedMap(), container.envVars?.toSortedMap())
   }
-
   @Test
   fun `Validate Container is not null`() {
     val container = this.buildValidateDataContainer()
@@ -2347,7 +2349,8 @@ class ContainerFactoryTests {
                 "TWIN_CACHE_HOST" to "this_is_a_host",
                 "TWIN_CACHE_PORT" to "6973",
                 "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-                "TWIN_CACHE_USERNAME" to "default")
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
             .toSortedMap(),
         container.envVars?.toSortedMap())
   }
@@ -2394,7 +2397,8 @@ class ContainerFactoryTests {
                 "TWIN_CACHE_HOST" to "this_is_a_host",
                 "TWIN_CACHE_PORT" to "6973",
                 "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-                "TWIN_CACHE_USERNAME" to "default")
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
             .toSortedMap(),
         container.envVars?.toSortedMap())
   }
@@ -2437,7 +2441,8 @@ class ContainerFactoryTests {
             "TWIN_CACHE_HOST" to "this_is_a_host",
             "TWIN_CACHE_PORT" to "6973",
             "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default"),
+            "TWIN_CACHE_USERNAME" to "default",
+            "CSM_ENTRYPOINT_LEGACY" to "true"),
         container.envVars)
   }
 
@@ -2494,7 +2499,8 @@ class ContainerFactoryTests {
                 "TWIN_CACHE_HOST" to "this_is_a_host",
                 "TWIN_CACHE_PORT" to "6973",
                 "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-                "TWIN_CACHE_USERNAME" to "default")
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
             .toSortedMap(),
         container.envVars?.toSortedMap())
   }
@@ -2519,36 +2525,39 @@ class ContainerFactoryTests {
 
     assertEquals(
         mapOf(
-            "IDENTITY_PROVIDER" to "azure",
-            "AZURE_TENANT_ID" to "12345678",
-            "AZURE_CLIENT_ID" to "98765432",
-            "AZURE_CLIENT_SECRET" to "azertyuiop",
-            "CSM_SIMULATION_ID" to "simulationrunid",
-            "CSM_API_URL" to "https://api.cosmotech.com",
-            "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
-            "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
-            "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
-            "AZURE_DATA_EXPLORER_RESOURCE_URI" to "https://phoenix.westeurope.kusto.windows.net",
-            "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
-                "https://ingest-phoenix.westeurope.kusto.windows.net",
-            "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
-            "CSM_ORGANIZATION_ID" to "Organizationid",
-            "CSM_WORKSPACE_ID" to "Workspaceid",
-            "CSM_SCENARIO_ID" to "Scenarioid",
-            "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
-            "CSM_CONTAINER_MODE" to "engine",
-            "CSM_PROBES_MEASURES_TOPIC" to
-                "amqps://csm-phoenix.servicebus.windows.net/organizationid-test",
-            "AZURE_EVENT_HUB_SHARED_ACCESS_POLICY" to "my-eventhub-access-policy",
-            "AZURE_EVENT_HUB_SHARED_ACCESS_KEY" to "a1b2c3d4e5==",
-            "CSM_AMQPCONSUMER_USER" to "my-eventhub-access-policy",
-            "CSM_AMQPCONSUMER_PASSWORD" to "a1b2c3d4e5==",
-            "CSM_SIMULATION" to "TestSimulation",
-            "TWIN_CACHE_HOST" to "this_is_a_host",
-            "TWIN_CACHE_PORT" to "6973",
-            "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default"),
-        container.envVars)
+                "IDENTITY_PROVIDER" to "azure",
+                "AZURE_TENANT_ID" to "12345678",
+                "AZURE_CLIENT_ID" to "98765432",
+                "AZURE_CLIENT_SECRET" to "azertyuiop",
+                "CSM_SIMULATION_ID" to "simulationrunid",
+                "CSM_API_URL" to "https://api.cosmotech.com",
+                "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
+                "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
+                "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
+                "AZURE_DATA_EXPLORER_RESOURCE_URI" to
+                    "https://phoenix.westeurope.kusto.windows.net",
+                "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
+                    "https://ingest-phoenix.westeurope.kusto.windows.net",
+                "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
+                "CSM_ORGANIZATION_ID" to "Organizationid",
+                "CSM_WORKSPACE_ID" to "Workspaceid",
+                "CSM_SCENARIO_ID" to "Scenarioid",
+                "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
+                "CSM_CONTAINER_MODE" to "engine",
+                "CSM_PROBES_MEASURES_TOPIC" to
+                    "amqps://csm-phoenix.servicebus.windows.net/organizationid-test",
+                "AZURE_EVENT_HUB_SHARED_ACCESS_POLICY" to "my-eventhub-access-policy",
+                "AZURE_EVENT_HUB_SHARED_ACCESS_KEY" to "a1b2c3d4e5==",
+                "CSM_AMQPCONSUMER_USER" to "my-eventhub-access-policy",
+                "CSM_AMQPCONSUMER_PASSWORD" to "a1b2c3d4e5==",
+                "CSM_SIMULATION" to "TestSimulation",
+                "TWIN_CACHE_HOST" to "this_is_a_host",
+                "TWIN_CACHE_PORT" to "6973",
+                "TWIN_CACHE_PASSWORD" to "this_is_a_password",
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
+            .toSortedMap(),
+        container.envVars?.toSortedMap())
   }
 
   @Test
@@ -2670,7 +2679,8 @@ class ContainerFactoryTests {
                 "TWIN_CACHE_HOST" to "this_is_a_host",
                 "TWIN_CACHE_PORT" to "6973",
                 "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-                "TWIN_CACHE_USERNAME" to "default")
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
             .toSortedMap(),
         container.envVars?.toSortedMap())
   }
@@ -2707,7 +2717,8 @@ class ContainerFactoryTests {
                 "TWIN_CACHE_HOST" to "this_is_a_host",
                 "TWIN_CACHE_PORT" to "6973",
                 "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-                "TWIN_CACHE_USERNAME" to "default")
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
             .toSortedMap(),
         container.envVars?.toSortedMap())
   }
@@ -2746,7 +2757,8 @@ class ContainerFactoryTests {
                 "TWIN_CACHE_HOST" to "this_is_a_host",
                 "TWIN_CACHE_PORT" to "6973",
                 "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-                "TWIN_CACHE_USERNAME" to "default")
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
             .toSortedMap(),
         container.envVars?.toSortedMap())
   }
@@ -2766,40 +2778,43 @@ class ContainerFactoryTests {
     assertNotNull(container.envVars)
     assertEquals(
         mapOf(
-            "IDENTITY_PROVIDER" to "azure",
-            "AZURE_TENANT_ID" to "12345678",
-            "AZURE_CLIENT_ID" to "98765432",
-            "AZURE_CLIENT_SECRET" to "azertyuiop",
-            "CSM_SIMULATION_ID" to "simulationrunid",
-            "CSM_API_URL" to "https://api.cosmotech.com",
-            "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
-            "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
-            "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
-            "AZURE_DATA_EXPLORER_RESOURCE_URI" to "https://phoenix.westeurope.kusto.windows.net",
-            "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
-                "https://ingest-phoenix.westeurope.kusto.windows.net",
-            "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
-            "CSM_ORGANIZATION_ID" to "Organizationid",
-            "CSM_WORKSPACE_ID" to "Workspaceid",
-            "CSM_SCENARIO_ID" to "Scenarioid",
-            "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
-            "CSM_CONTAINER_MODE" to "engine",
-            "CSM_PROBES_MEASURES_TOPIC" to
-                "amqps://organizationid-test.servicebus.windows.net/probesmeasures",
-            "AZURE_EVENT_HUB_SHARED_ACCESS_POLICY" to name,
-            "AZURE_EVENT_HUB_SHARED_ACCESS_KEY" to key,
-            "CSM_AMQPCONSUMER_USER" to name,
-            "CSM_AMQPCONSUMER_PASSWORD" to key,
-            "CSM_CONTROL_PLANE_TOPIC" to
-                "amqps://organizationid-test.servicebus.windows.net/scenariorun",
-            "CSM_CONTROL_PLANE_USER" to name,
-            "CSM_CONTROL_PLANE_PASSWORD" to key,
-            "CSM_SIMULATION" to "TestSimulation",
-            "TWIN_CACHE_HOST" to "this_is_a_host",
-            "TWIN_CACHE_PORT" to "6973",
-            "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default"),
-        container.envVars)
+                "IDENTITY_PROVIDER" to "azure",
+                "AZURE_TENANT_ID" to "12345678",
+                "AZURE_CLIENT_ID" to "98765432",
+                "AZURE_CLIENT_SECRET" to "azertyuiop",
+                "CSM_SIMULATION_ID" to "simulationrunid",
+                "CSM_API_URL" to "https://api.cosmotech.com",
+                "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
+                "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
+                "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
+                "AZURE_DATA_EXPLORER_RESOURCE_URI" to
+                    "https://phoenix.westeurope.kusto.windows.net",
+                "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
+                    "https://ingest-phoenix.westeurope.kusto.windows.net",
+                "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
+                "CSM_ORGANIZATION_ID" to "Organizationid",
+                "CSM_WORKSPACE_ID" to "Workspaceid",
+                "CSM_SCENARIO_ID" to "Scenarioid",
+                "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
+                "CSM_CONTAINER_MODE" to "engine",
+                "CSM_PROBES_MEASURES_TOPIC" to
+                    "amqps://organizationid-test.servicebus.windows.net/probesmeasures",
+                "AZURE_EVENT_HUB_SHARED_ACCESS_POLICY" to name,
+                "AZURE_EVENT_HUB_SHARED_ACCESS_KEY" to key,
+                "CSM_AMQPCONSUMER_USER" to name,
+                "CSM_AMQPCONSUMER_PASSWORD" to key,
+                "CSM_CONTROL_PLANE_TOPIC" to
+                    "amqps://organizationid-test.servicebus.windows.net/scenariorun",
+                "CSM_CONTROL_PLANE_USER" to name,
+                "CSM_CONTROL_PLANE_PASSWORD" to key,
+                "CSM_SIMULATION" to "TestSimulation",
+                "TWIN_CACHE_HOST" to "this_is_a_host",
+                "TWIN_CACHE_PORT" to "6973",
+                "TWIN_CACHE_PASSWORD" to "this_is_a_password",
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
+            .toSortedMap(),
+        container.envVars?.toSortedMap())
   }
 
   @Test
@@ -2813,40 +2828,43 @@ class ContainerFactoryTests {
     assertNotNull(container.envVars)
     assertEquals(
         mapOf(
-            "IDENTITY_PROVIDER" to "azure",
-            "AZURE_TENANT_ID" to "12345678",
-            "AZURE_CLIENT_ID" to "98765432",
-            "AZURE_CLIENT_SECRET" to "azertyuiop",
-            "CSM_SIMULATION_ID" to "simulationrunid",
-            "CSM_API_URL" to "https://api.cosmotech.com",
-            "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
-            "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
-            "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
-            "AZURE_DATA_EXPLORER_RESOURCE_URI" to "https://phoenix.westeurope.kusto.windows.net",
-            "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
-                "https://ingest-phoenix.westeurope.kusto.windows.net",
-            "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
-            "CSM_ORGANIZATION_ID" to "Organizationid",
-            "CSM_WORKSPACE_ID" to "Workspaceid",
-            "CSM_SCENARIO_ID" to "Scenarioid",
-            "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
-            "CSM_CONTAINER_MODE" to "engine",
-            "CSM_PROBES_MEASURES_TOPIC" to
-                "amqps://organizationid-test.servicebus.windows.net/probesmeasures",
-            "AZURE_EVENT_HUB_SHARED_ACCESS_POLICY" to name,
-            "AZURE_EVENT_HUB_SHARED_ACCESS_KEY" to key,
-            "CSM_AMQPCONSUMER_USER" to name,
-            "CSM_AMQPCONSUMER_PASSWORD" to key,
-            "CSM_CONTROL_PLANE_TOPIC" to
-                "amqps://organizationid-test.servicebus.windows.net/scenariorun",
-            "CSM_CONTROL_PLANE_USER" to name,
-            "CSM_CONTROL_PLANE_PASSWORD" to key,
-            "CSM_SIMULATION" to "TestSimulation",
-            "TWIN_CACHE_HOST" to "this_is_a_host",
-            "TWIN_CACHE_PORT" to "6973",
-            "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default"),
-        container.envVars)
+                "IDENTITY_PROVIDER" to "azure",
+                "AZURE_TENANT_ID" to "12345678",
+                "AZURE_CLIENT_ID" to "98765432",
+                "AZURE_CLIENT_SECRET" to "azertyuiop",
+                "CSM_SIMULATION_ID" to "simulationrunid",
+                "CSM_API_URL" to "https://api.cosmotech.com",
+                "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
+                "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
+                "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
+                "AZURE_DATA_EXPLORER_RESOURCE_URI" to
+                    "https://phoenix.westeurope.kusto.windows.net",
+                "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
+                    "https://ingest-phoenix.westeurope.kusto.windows.net",
+                "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
+                "CSM_ORGANIZATION_ID" to "Organizationid",
+                "CSM_WORKSPACE_ID" to "Workspaceid",
+                "CSM_SCENARIO_ID" to "Scenarioid",
+                "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
+                "CSM_CONTAINER_MODE" to "engine",
+                "CSM_PROBES_MEASURES_TOPIC" to
+                    "amqps://organizationid-test.servicebus.windows.net/probesmeasures",
+                "AZURE_EVENT_HUB_SHARED_ACCESS_POLICY" to name,
+                "AZURE_EVENT_HUB_SHARED_ACCESS_KEY" to key,
+                "CSM_AMQPCONSUMER_USER" to name,
+                "CSM_AMQPCONSUMER_PASSWORD" to key,
+                "CSM_CONTROL_PLANE_TOPIC" to
+                    "amqps://organizationid-test.servicebus.windows.net/scenariorun",
+                "CSM_CONTROL_PLANE_USER" to name,
+                "CSM_CONTROL_PLANE_PASSWORD" to key,
+                "CSM_SIMULATION" to "TestSimulation",
+                "TWIN_CACHE_HOST" to "this_is_a_host",
+                "TWIN_CACHE_PORT" to "6973",
+                "TWIN_CACHE_PASSWORD" to "this_is_a_password",
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
+            .toSortedMap(),
+        container.envVars?.toSortedMap())
   }
 
   @Test
@@ -2860,34 +2878,37 @@ class ContainerFactoryTests {
     assertNotNull(container.envVars)
     assertEquals(
         mapOf(
-            "IDENTITY_PROVIDER" to "azure",
-            "AZURE_TENANT_ID" to "12345678",
-            "AZURE_CLIENT_ID" to "98765432",
-            "AZURE_CLIENT_SECRET" to "azertyuiop",
-            "CSM_SIMULATION_ID" to "simulationrunid",
-            "CSM_API_URL" to "https://api.cosmotech.com",
-            "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
-            "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
-            "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
-            "AZURE_DATA_EXPLORER_RESOURCE_URI" to "https://phoenix.westeurope.kusto.windows.net",
-            "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
-                "https://ingest-phoenix.westeurope.kusto.windows.net",
-            "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
-            "CSM_ORGANIZATION_ID" to "Organizationid",
-            "CSM_WORKSPACE_ID" to "Workspaceid",
-            "CSM_SCENARIO_ID" to "Scenarioid",
-            "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
-            "CSM_CONTAINER_MODE" to "engine",
-            "CSM_PROBES_MEASURES_TOPIC" to
-                "amqps://organizationid-test.servicebus.windows.net/probesmeasures",
-            "CSM_CONTROL_PLANE_TOPIC" to
-                "amqps://organizationid-test.servicebus.windows.net/scenariorun",
-            "CSM_SIMULATION" to "TestSimulation",
-            "TWIN_CACHE_HOST" to "this_is_a_host",
-            "TWIN_CACHE_PORT" to "6973",
-            "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default"),
-        container.envVars)
+                "IDENTITY_PROVIDER" to "azure",
+                "AZURE_TENANT_ID" to "12345678",
+                "AZURE_CLIENT_ID" to "98765432",
+                "AZURE_CLIENT_SECRET" to "azertyuiop",
+                "CSM_SIMULATION_ID" to "simulationrunid",
+                "CSM_API_URL" to "https://api.cosmotech.com",
+                "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
+                "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
+                "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
+                "AZURE_DATA_EXPLORER_RESOURCE_URI" to
+                    "https://phoenix.westeurope.kusto.windows.net",
+                "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
+                    "https://ingest-phoenix.westeurope.kusto.windows.net",
+                "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
+                "CSM_ORGANIZATION_ID" to "Organizationid",
+                "CSM_WORKSPACE_ID" to "Workspaceid",
+                "CSM_SCENARIO_ID" to "Scenarioid",
+                "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
+                "CSM_CONTAINER_MODE" to "engine",
+                "CSM_PROBES_MEASURES_TOPIC" to
+                    "amqps://organizationid-test.servicebus.windows.net/probesmeasures",
+                "CSM_CONTROL_PLANE_TOPIC" to
+                    "amqps://organizationid-test.servicebus.windows.net/scenariorun",
+                "CSM_SIMULATION" to "TestSimulation",
+                "TWIN_CACHE_HOST" to "this_is_a_host",
+                "TWIN_CACHE_PORT" to "6973",
+                "TWIN_CACHE_PASSWORD" to "this_is_a_password",
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
+            .toSortedMap(),
+        container.envVars?.toSortedMap())
   }
 
   @Test
@@ -2901,40 +2922,43 @@ class ContainerFactoryTests {
     assertNotNull(container.envVars)
     assertEquals(
         mapOf(
-            "IDENTITY_PROVIDER" to "azure",
-            "AZURE_TENANT_ID" to "12345678",
-            "AZURE_CLIENT_ID" to "98765432",
-            "AZURE_CLIENT_SECRET" to "azertyuiop",
-            "CSM_SIMULATION_ID" to "simulationrunid",
-            "CSM_API_URL" to "https://api.cosmotech.com",
-            "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
-            "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
-            "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
-            "AZURE_DATA_EXPLORER_RESOURCE_URI" to "https://phoenix.westeurope.kusto.windows.net",
-            "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
-                "https://ingest-phoenix.westeurope.kusto.windows.net",
-            "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
-            "CSM_ORGANIZATION_ID" to "Organizationid",
-            "CSM_WORKSPACE_ID" to "Workspaceid",
-            "CSM_SCENARIO_ID" to "Scenarioid",
-            "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
-            "CSM_CONTAINER_MODE" to "engine",
-            "CSM_PROBES_MEASURES_TOPIC" to
-                "amqps://organizationid-test.servicebus.windows.net/probesmeasures",
-            "AZURE_EVENT_HUB_SHARED_ACCESS_POLICY" to name,
-            "AZURE_EVENT_HUB_SHARED_ACCESS_KEY" to key,
-            "CSM_AMQPCONSUMER_USER" to name,
-            "CSM_AMQPCONSUMER_PASSWORD" to key,
-            "CSM_CONTROL_PLANE_TOPIC" to
-                "amqps://organizationid-test.servicebus.windows.net/scenariorun",
-            "CSM_CONTROL_PLANE_USER" to name,
-            "CSM_CONTROL_PLANE_PASSWORD" to key,
-            "CSM_SIMULATION" to "TestSimulation",
-            "TWIN_CACHE_HOST" to "this_is_a_host",
-            "TWIN_CACHE_PORT" to "6973",
-            "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default"),
-        container.envVars)
+                "IDENTITY_PROVIDER" to "azure",
+                "AZURE_TENANT_ID" to "12345678",
+                "AZURE_CLIENT_ID" to "98765432",
+                "AZURE_CLIENT_SECRET" to "azertyuiop",
+                "CSM_SIMULATION_ID" to "simulationrunid",
+                "CSM_API_URL" to "https://api.cosmotech.com",
+                "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
+                "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
+                "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
+                "AZURE_DATA_EXPLORER_RESOURCE_URI" to
+                    "https://phoenix.westeurope.kusto.windows.net",
+                "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
+                    "https://ingest-phoenix.westeurope.kusto.windows.net",
+                "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
+                "CSM_ORGANIZATION_ID" to "Organizationid",
+                "CSM_WORKSPACE_ID" to "Workspaceid",
+                "CSM_SCENARIO_ID" to "Scenarioid",
+                "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
+                "CSM_CONTAINER_MODE" to "engine",
+                "CSM_PROBES_MEASURES_TOPIC" to
+                    "amqps://organizationid-test.servicebus.windows.net/probesmeasures",
+                "AZURE_EVENT_HUB_SHARED_ACCESS_POLICY" to name,
+                "AZURE_EVENT_HUB_SHARED_ACCESS_KEY" to key,
+                "CSM_AMQPCONSUMER_USER" to name,
+                "CSM_AMQPCONSUMER_PASSWORD" to key,
+                "CSM_CONTROL_PLANE_TOPIC" to
+                    "amqps://organizationid-test.servicebus.windows.net/scenariorun",
+                "CSM_CONTROL_PLANE_USER" to name,
+                "CSM_CONTROL_PLANE_PASSWORD" to key,
+                "CSM_SIMULATION" to "TestSimulation",
+                "TWIN_CACHE_HOST" to "this_is_a_host",
+                "TWIN_CACHE_PORT" to "6973",
+                "TWIN_CACHE_PASSWORD" to "this_is_a_password",
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
+            .toSortedMap(),
+        container.envVars?.toSortedMap())
   }
 
   @Test
@@ -2963,36 +2987,39 @@ class ContainerFactoryTests {
     assertNotNull(container.envVars)
     assertEquals(
         mapOf(
-            "IDENTITY_PROVIDER" to "azure",
-            "AZURE_TENANT_ID" to "12345678",
-            "AZURE_CLIENT_ID" to "98765432",
-            "AZURE_CLIENT_SECRET" to "azertyuiop",
-            "CSM_SIMULATION_ID" to "simulationrunid",
-            "CSM_API_URL" to "https://api.cosmotech.com",
-            "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
-            "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
-            "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
-            "AZURE_DATA_EXPLORER_RESOURCE_URI" to "https://phoenix.westeurope.kusto.windows.net",
-            "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
-                "https://ingest-phoenix.westeurope.kusto.windows.net",
-            "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
-            "CSM_ORGANIZATION_ID" to "Organizationid",
-            "CSM_WORKSPACE_ID" to "Workspaceid",
-            "CSM_SCENARIO_ID" to "Scenarioid",
-            "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
-            "CSM_CONTAINER_MODE" to "engine",
-            "CSM_PROBES_MEASURES_TOPIC" to
-                "amqps://organizationid-test.servicebus.windows.net/probesmeasures",
-            "AZURE_EVENT_HUB_SHARED_ACCESS_POLICY" to name,
-            "AZURE_EVENT_HUB_SHARED_ACCESS_KEY" to key,
-            "CSM_AMQPCONSUMER_USER" to name,
-            "CSM_AMQPCONSUMER_PASSWORD" to key,
-            "CSM_SIMULATION" to "TestSimulation",
-            "TWIN_CACHE_HOST" to "this_is_a_host",
-            "TWIN_CACHE_PORT" to "6973",
-            "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default"),
-        container.envVars)
+                "IDENTITY_PROVIDER" to "azure",
+                "AZURE_TENANT_ID" to "12345678",
+                "AZURE_CLIENT_ID" to "98765432",
+                "AZURE_CLIENT_SECRET" to "azertyuiop",
+                "CSM_SIMULATION_ID" to "simulationrunid",
+                "CSM_API_URL" to "https://api.cosmotech.com",
+                "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
+                "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
+                "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
+                "AZURE_DATA_EXPLORER_RESOURCE_URI" to
+                    "https://phoenix.westeurope.kusto.windows.net",
+                "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
+                    "https://ingest-phoenix.westeurope.kusto.windows.net",
+                "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
+                "CSM_ORGANIZATION_ID" to "Organizationid",
+                "CSM_WORKSPACE_ID" to "Workspaceid",
+                "CSM_SCENARIO_ID" to "Scenarioid",
+                "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
+                "CSM_CONTAINER_MODE" to "engine",
+                "CSM_PROBES_MEASURES_TOPIC" to
+                    "amqps://organizationid-test.servicebus.windows.net/probesmeasures",
+                "AZURE_EVENT_HUB_SHARED_ACCESS_POLICY" to name,
+                "AZURE_EVENT_HUB_SHARED_ACCESS_KEY" to key,
+                "CSM_AMQPCONSUMER_USER" to name,
+                "CSM_AMQPCONSUMER_PASSWORD" to key,
+                "CSM_SIMULATION" to "TestSimulation",
+                "TWIN_CACHE_HOST" to "this_is_a_host",
+                "TWIN_CACHE_PORT" to "6973",
+                "TWIN_CACHE_PASSWORD" to "this_is_a_password",
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
+            .toSortedMap(),
+        container.envVars?.toSortedMap())
   }
 
   @Test
@@ -3034,11 +3061,73 @@ class ContainerFactoryTests {
                 "TWIN_CACHE_HOST" to "this_is_a_host",
                 "TWIN_CACHE_PORT" to "6973",
                 "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-                "TWIN_CACHE_USERNAME" to "default")
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
             .toSortedMap(),
         container.envVars?.toSortedMap())
   }
+  @Test
+  fun `CSMOrchestrator Container is not null`() {
+    val container = this.buildCSMOrchestratorContainer()
+    assertNotNull(container)
+  }
 
+  @Test
+  fun `CSMOrchestrator Container name valid`() {
+    val container = this.buildCSMOrchestratorContainer()
+    assertEquals("CSMOrchestrator", container.name)
+  }
+
+  @Test
+  fun `CSMOrchestrator Container env vars valid`() {
+    val container = this.buildCSMOrchestratorContainer()
+    this.validateCSMOrchestratorContainer(container)
+  }
+
+  @Test
+  fun `Build all containers for a Scenario with csm-orc count`() {
+    val scenario = getScenario()
+    val datasets = listOf(getDataset())
+    val connectors = listOf(getConnector())
+    val workspace = getWorkspace()
+    val solution = getCSMOrcSolution()
+    val containers =
+        factory.buildContainersPipeline(
+            scenario,
+            datasets,
+            connectors,
+            workspace,
+            getOrganization(),
+            solution,
+            CSM_SIMULATION_ID,
+            scenarioRunLabel = NODE_LABEL_DEFAULT,
+            scenarioRunSizing = BASIC_SIZING)
+    assertEquals(containers.size, 1)
+  }
+  @Test
+  fun `Build all containers for a Scenario with csm-orc list`() {
+    val scenario = getScenario()
+    val datasets = listOf(getDataset())
+    val connectors = listOf(getConnector())
+    val workspace = getWorkspace()
+    val solution = getCSMOrcSolution()
+    val containers =
+        factory.buildContainersPipeline(
+            scenario,
+            datasets,
+            connectors,
+            workspace,
+            getOrganization(),
+            solution,
+            CSM_SIMULATION_ID,
+            scenarioRunLabel = NODE_LABEL_DEFAULT,
+            scenarioRunSizing = BASIC_SIZING)
+    val expected =
+        listOf(
+            "CSMOrchestrator",
+        )
+    assertEquals(expected, containers.map { container -> container.name })
+  }
   private fun buildApplyParametersContainer(): ScenarioRunContainer {
     return factory.buildApplyParametersContainer(
         getOrganization(),
@@ -3104,6 +3193,18 @@ class ContainerFactoryTests {
         customSizing = BASIC_SIZING)
   }
 
+  private fun buildCSMOrchestratorContainer(): ScenarioRunContainer {
+    return factory.buildCSMOrchestratorContainer(
+        getOrganization(),
+        getWorkspace(),
+        getScenario(),
+        getSolution(),
+        "testruntemplate",
+        CSM_SIMULATION_ID,
+        nodeSizingLabel = NODE_LABEL_DEFAULT,
+        customSizing = BASIC_SIZING)
+  }
+
   private fun validateEnvVarsSolutionContainer(container: ScenarioRunContainer?, mode: String) {
     val expected =
         mapOf(
@@ -3133,7 +3234,41 @@ class ContainerFactoryTests {
             "TWIN_CACHE_HOST" to "this_is_a_host",
             "TWIN_CACHE_PORT" to "6973",
             "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default")
+            "TWIN_CACHE_USERNAME" to "default",
+            "CSM_ENTRYPOINT_LEGACY" to "true")
+    assertEquals(expected.toSortedMap(), container?.envVars?.toSortedMap())
+  }
+  private fun validateCSMOrchestratorContainer(container: ScenarioRunContainer?) {
+    val expected =
+        mapOf(
+            "IDENTITY_PROVIDER" to "azure",
+            "AZURE_TENANT_ID" to "12345678",
+            "AZURE_CLIENT_ID" to "98765432",
+            "AZURE_CLIENT_SECRET" to "azertyuiop",
+            "CSM_SIMULATION_ID" to "simulationrunid",
+            "CSM_API_URL" to "https://api.cosmotech.com",
+            "CSM_API_SCOPE" to "http://dev.api.cosmotech.com/.default",
+            "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
+            "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
+            "AZURE_DATA_EXPLORER_RESOURCE_URI" to "https://phoenix.westeurope.kusto.windows.net",
+            "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
+                "https://ingest-phoenix.westeurope.kusto.windows.net",
+            "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
+            "CSM_ORGANIZATION_ID" to "Organizationid",
+            "CSM_WORKSPACE_ID" to "Workspaceid",
+            "CSM_SCENARIO_ID" to "Scenarioid",
+            "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
+            "CSM_CONTAINER_MODE" to "csm-orc",
+            "CSM_PROBES_MEASURES_TOPIC" to
+                "amqps://csm-phoenix.servicebus.windows.net/organizationid-test",
+            "CSM_CONTROL_PLANE_TOPIC" to
+                "amqps://csm-phoenix.servicebus.windows.net/organizationid-test-scenariorun",
+            "CSM_SIMULATION" to "TestSimulation",
+            "TWIN_CACHE_HOST" to "this_is_a_host",
+            "TWIN_CACHE_PORT" to "6973",
+            "TWIN_CACHE_PASSWORD" to "this_is_a_password",
+            "TWIN_CACHE_USERNAME" to "default",
+            "CSM_ENTRYPOINT_LEGACY" to "false")
     assertEquals(expected.toSortedMap(), container?.envVars?.toSortedMap())
   }
 
@@ -3374,7 +3509,6 @@ class ContainerFactoryTests {
         sendInputToDataWarehouse = false,
     )
   }
-
   private fun getSolution(): Solution {
     return Solution(
         id = "1",
@@ -3510,7 +3644,16 @@ class ContainerFactoryTests {
         runTemplates = mutableListOf(getRunTemplateLocalSources()),
     )
   }
-
+  private fun getCSMOrcSolution(): Solution {
+    return Solution(
+        id = "1",
+        key = "TestSolution",
+        name = "Test Solution",
+        repository = "cosmotech/testsolution_simulator",
+        version = "1.0.0",
+        runTemplates = mutableListOf(getCSMOrcRunTemplate()),
+    )
+  }
   private fun getRunTemplate(): RunTemplate {
     return RunTemplate(
         id = "testruntemplate",
@@ -3526,6 +3669,7 @@ class ContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3545,6 +3689,7 @@ class ContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3564,6 +3709,7 @@ class ContainerFactoryTests {
         run = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3583,6 +3729,7 @@ class ContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3600,6 +3747,7 @@ class ContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3618,6 +3766,7 @@ class ContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3636,6 +3785,7 @@ class ContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3654,6 +3804,7 @@ class ContainerFactoryTests {
         sendDatasetsToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3672,6 +3823,7 @@ class ContainerFactoryTests {
         sendInputParametersToDataWarehouse = false,
         preRun = false,
         postRun = false,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3695,6 +3847,7 @@ class ContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3718,6 +3871,16 @@ class ContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
+    )
+  }
+  private fun getCSMOrcRunTemplate(): RunTemplate {
+    return RunTemplate(
+        id = "testruntemplate",
+        name = "Test Run",
+        csmSimulation = "TestSimulation",
+        computeSize = "highcpupool",
+        orchestratorType = RunTemplateOrchestrator.csmMinusOrc,
     )
   }
 

--- a/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/OktaContainerFactoryTests.kt
+++ b/scenariorun/src/test/kotlin/com/cosmotech/scenariorun/OktaContainerFactoryTests.kt
@@ -33,6 +33,7 @@ import com.cosmotech.scenariorun.container.StartInfo
 import com.cosmotech.scenariorun.domain.ScenarioRunContainer
 import com.cosmotech.solution.api.SolutionApiService
 import com.cosmotech.solution.domain.RunTemplate
+import com.cosmotech.solution.domain.RunTemplateOrchestrator
 import com.cosmotech.solution.domain.RunTemplateParameter
 import com.cosmotech.solution.domain.RunTemplateParameterGroup
 import com.cosmotech.solution.domain.RunTemplateStepSource
@@ -1080,7 +1081,8 @@ class OktaContainerFactoryTests {
             "TWIN_CACHE_HOST" to "this_is_a_host",
             "TWIN_CACHE_PORT" to "6973",
             "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default")
+            "TWIN_CACHE_USERNAME" to "default",
+            "CSM_ENTRYPOINT_LEGACY" to "true")
     assertEquals(expected.toSortedMap(), container.envVars?.toSortedMap())
   }
 
@@ -1122,7 +1124,8 @@ class OktaContainerFactoryTests {
             "TWIN_CACHE_HOST" to "this_is_a_host",
             "TWIN_CACHE_PORT" to "6973",
             "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default")
+            "TWIN_CACHE_USERNAME" to "default",
+            "CSM_ENTRYPOINT_LEGACY" to "true")
     assertEquals(expected.toSortedMap(), container.envVars?.toSortedMap())
   }
 
@@ -2355,7 +2358,8 @@ class OktaContainerFactoryTests {
                 "TWIN_CACHE_HOST" to "this_is_a_host",
                 "TWIN_CACHE_PORT" to "6973",
                 "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-                "TWIN_CACHE_USERNAME" to "default")
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
             .toSortedMap(),
         container.envVars?.toSortedMap())
   }
@@ -2405,7 +2409,8 @@ class OktaContainerFactoryTests {
                 "TWIN_CACHE_HOST" to "this_is_a_host",
                 "TWIN_CACHE_PORT" to "6973",
                 "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-                "TWIN_CACHE_USERNAME" to "default")
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
             .toSortedMap(),
         container.envVars?.toSortedMap())
   }
@@ -2467,7 +2472,8 @@ class OktaContainerFactoryTests {
                 "TWIN_CACHE_HOST" to "this_is_a_host",
                 "TWIN_CACHE_PORT" to "6973",
                 "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-                "TWIN_CACHE_USERNAME" to "default")
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
             .toSortedMap(),
         container.envVars?.toSortedMap())
   }
@@ -2480,6 +2486,68 @@ class OktaContainerFactoryTests {
             authentication = Authentication(strategy = SHARED_ACCESS_POLICY))
 
     assertThrows(IllegalStateException::class.java) { buildRunContainer() }
+  }
+  @Test
+  fun `CSMOrchestrator Container is not null`() {
+    val container = this.buildCSMOrchestratorContainer()
+    assertNotNull(container)
+  }
+
+  @Test
+  fun `CSMOrchestrator Container name valid`() {
+    val container = this.buildCSMOrchestratorContainer()
+    assertEquals("CSMOrchestrator", container.name)
+  }
+
+  @Test
+  fun `CSMOrchestrator Container env vars valid`() {
+    val container = this.buildCSMOrchestratorContainer()
+    this.validateCSMOrchestratorContainer(container)
+  }
+
+  @Test
+  fun `Build all containers for a Scenario with csm-orc count`() {
+    val scenario = getScenario()
+    val datasets = listOf(getDataset())
+    val connectors = listOf(getConnector())
+    val workspace = getWorkspace()
+    val solution = getCSMOrcSolution()
+    val containers =
+        factory.buildContainersPipeline(
+            scenario,
+            datasets,
+            connectors,
+            workspace,
+            getOrganization(),
+            solution,
+            CSM_SIMULATION_ID,
+            scenarioRunLabel = NODE_LABEL_DEFAULT,
+            scenarioRunSizing = BASIC_SIZING)
+    assertEquals(containers.size, 1)
+  }
+  @Test
+  fun `Build all containers for a Scenario with csm-orc list`() {
+    val scenario = getScenario()
+    val datasets = listOf(getDataset())
+    val connectors = listOf(getConnector())
+    val workspace = getWorkspace()
+    val solution = getCSMOrcSolution()
+    val containers =
+        factory.buildContainersPipeline(
+            scenario,
+            datasets,
+            connectors,
+            workspace,
+            getOrganization(),
+            solution,
+            CSM_SIMULATION_ID,
+            scenarioRunLabel = NODE_LABEL_DEFAULT,
+            scenarioRunSizing = BASIC_SIZING)
+    val expected =
+        listOf(
+            "CSMOrchestrator",
+        )
+    assertEquals(expected, containers.map { container -> container.name })
   }
 
   private fun getStartInfoFromIds(): StartInfo {
@@ -2597,7 +2665,8 @@ class OktaContainerFactoryTests {
                 "TWIN_CACHE_HOST" to "this_is_a_host",
                 "TWIN_CACHE_PORT" to "6973",
                 "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-                "TWIN_CACHE_USERNAME" to "default")
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
             .toSortedMap(),
         container.envVars?.toSortedMap())
   }
@@ -2644,7 +2713,8 @@ class OktaContainerFactoryTests {
                 "TWIN_CACHE_HOST" to "this_is_a_host",
                 "TWIN_CACHE_PORT" to "6973",
                 "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-                "TWIN_CACHE_USERNAME" to "default")
+                "TWIN_CACHE_USERNAME" to "default",
+                "CSM_ENTRYPOINT_LEGACY" to "true")
             .toSortedMap(),
         container.envVars?.toSortedMap())
   }
@@ -2709,6 +2779,18 @@ class OktaContainerFactoryTests {
         customSizing = BASIC_SIZING)
   }
 
+  private fun buildCSMOrchestratorContainer(): ScenarioRunContainer {
+    return factory.buildCSMOrchestratorContainer(
+        getOrganization(),
+        getWorkspace(),
+        getScenario(),
+        getSolution(),
+        "testruntemplate",
+        CSM_SIMULATION_ID,
+        nodeSizingLabel = NODE_LABEL_DEFAULT,
+        customSizing = BASIC_SIZING)
+  }
+
   private fun validateEnvVarsSolutionContainer(container: ScenarioRunContainer?, mode: String) {
     val expected =
         mapOf(
@@ -2741,7 +2823,44 @@ class OktaContainerFactoryTests {
             "TWIN_CACHE_HOST" to "this_is_a_host",
             "TWIN_CACHE_PORT" to "6973",
             "TWIN_CACHE_PASSWORD" to "this_is_a_password",
-            "TWIN_CACHE_USERNAME" to "default")
+            "TWIN_CACHE_USERNAME" to "default",
+            "CSM_ENTRYPOINT_LEGACY" to "true")
+    assertEquals(expected.toSortedMap(), container?.envVars?.toSortedMap())
+  }
+  private fun validateCSMOrchestratorContainer(container: ScenarioRunContainer?) {
+    val expected =
+        mapOf(
+            "IDENTITY_PROVIDER" to "okta",
+            "OKTA_CLIENT_ID" to "123456",
+            "OKTA_CLIENT_SECRET" to "azerty",
+            "OKTA_CLIENT_ISSUER" to "http://okta.com/oauth2/default",
+            "AZURE_TENANT_ID" to "12345678",
+            "AZURE_CLIENT_ID" to "98765432",
+            "AZURE_CLIENT_SECRET" to "azertyuiop",
+            "CSM_SIMULATION_ID" to "simulationrunid",
+            "CSM_API_URL" to "https://api.cosmotech.com",
+            "CSM_API_SCOPE" to "scope1,scope2",
+            "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
+            "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
+            "AZURE_DATA_EXPLORER_RESOURCE_URI" to "https://phoenix.westeurope.kusto.windows.net",
+            "AZURE_DATA_EXPLORER_RESOURCE_INGEST_URI" to
+                "https://ingest-phoenix.westeurope.kusto.windows.net",
+            "AZURE_DATA_EXPLORER_DATABASE_NAME" to "organizationid-test",
+            "CSM_ORGANIZATION_ID" to "Organizationid",
+            "CSM_WORKSPACE_ID" to "Workspaceid",
+            "CSM_SCENARIO_ID" to "Scenarioid",
+            "CSM_RUN_TEMPLATE_ID" to "testruntemplate",
+            "CSM_CONTAINER_MODE" to "csm-orc",
+            "CSM_PROBES_MEASURES_TOPIC" to
+                "amqps://csm-phoenix.servicebus.windows.net/organizationid-test",
+            "CSM_CONTROL_PLANE_TOPIC" to
+                "amqps://csm-phoenix.servicebus.windows.net/organizationid-test-scenariorun",
+            "CSM_SIMULATION" to "TestSimulation",
+            "TWIN_CACHE_HOST" to "this_is_a_host",
+            "TWIN_CACHE_PORT" to "6973",
+            "TWIN_CACHE_PASSWORD" to "this_is_a_password",
+            "TWIN_CACHE_USERNAME" to "default",
+            "CSM_ENTRYPOINT_LEGACY" to "false")
     assertEquals(expected.toSortedMap(), container?.envVars?.toSortedMap())
   }
 
@@ -3110,6 +3229,16 @@ class OktaContainerFactoryTests {
         runTemplates = mutableListOf(getRunTemplateLocalSources()),
     )
   }
+  private fun getCSMOrcSolution(): Solution {
+    return Solution(
+        id = "1",
+        key = "TestSolution",
+        name = "Test Solution",
+        repository = "cosmotech/testsolution_simulator",
+        version = "1.0.0",
+        runTemplates = mutableListOf(getCSMOrcRunTemplate()),
+    )
+  }
 
   private fun getRunTemplate(): RunTemplate {
     return RunTemplate(
@@ -3126,6 +3255,7 @@ class OktaContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3145,6 +3275,7 @@ class OktaContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3164,6 +3295,7 @@ class OktaContainerFactoryTests {
         run = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3183,6 +3315,7 @@ class OktaContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3200,6 +3333,7 @@ class OktaContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3218,6 +3352,7 @@ class OktaContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3236,6 +3371,7 @@ class OktaContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3254,6 +3390,7 @@ class OktaContainerFactoryTests {
         sendDatasetsToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3272,6 +3409,7 @@ class OktaContainerFactoryTests {
         sendInputParametersToDataWarehouse = false,
         preRun = false,
         postRun = false,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3295,6 +3433,7 @@ class OktaContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
     )
   }
 
@@ -3318,6 +3457,16 @@ class OktaContainerFactoryTests {
         sendInputParametersToDataWarehouse = true,
         preRun = true,
         postRun = true,
+        orchestratorType = RunTemplateOrchestrator.argoMinusWorkflow,
+    )
+  }
+  private fun getCSMOrcRunTemplate(): RunTemplate {
+    return RunTemplate(
+        id = "testruntemplate",
+        name = "Test Run",
+        csmSimulation = "TestSimulation",
+        computeSize = "highcpupool",
+        orchestratorType = RunTemplateOrchestrator.csmMinusOrc,
     )
   }
 

--- a/solution/src/main/openapi/solution.yaml
+++ b/solution/src/main/openapi/solution.yaml
@@ -694,6 +694,8 @@ components:
         runTemplateSourceDir:
           type: string
           description: an optional directory where to find the run template source
+        orchestratorType:
+          $ref: "#/components/schemas/RunTemplateOrchestrator"
         executionTimeout:
           type: integer
           description: an optional duration in seconds in which a workflow is allowed to run
@@ -721,6 +723,10 @@ components:
       required:
         - enable
 
+    RunTemplateOrchestrator:
+      type: string
+      description: the Orchestrator to use for the Run Template
+      enum: ["argo-workflow","csm-orc"]
     RunTemplateHandlerId:
       type: string
       description: the Run Template step handler identifier


### PR DESCRIPTION
PROD-12221 Support csm-orc in platform API
Definition of Done

    When executing a scenario run from API, user can choose between legacy or Python orchestrator

    Deployed and tested in phoenixdev

Note

    Default behavior to be changed: csm-orc should be the default orchestration mode in API