### PR TITLE
fix: fix Python client error when fetching legacy datasets

### DIFF
--- a/dataset/src/main/openapi/dataset.yaml
+++ b/dataset/src/main/openapi/dataset.yaml
@@ -1509,6 +1509,7 @@ components:
         ingestionStatus:
           type: string
           description: the Dataset ingestion status
+          nullable: true
           enum:
             - NONE
             - PENDING
@@ -1517,6 +1518,7 @@ components:
         twincacheStatus:
           type: string
           description: the twincache data status
+          nullable: true
           enum:
             - EMPTY
             - FULL


### PR DESCRIPTION
Prior to this commit, a call to `find_dataset_by_id` on a dataset created with v2 of the Cosmo Tech API raised this error:
```
  cosmotech_api.exceptions.ApiValueError: Invalid value for
  `ingestion_status` (None), must be one of ['NONE', 'PENDING', 'ERROR',
  'SUCCESS']
```
or a similar error for `twincacheStatus`. This is because "legacy" datasets have null values for these attributes (and for the attribute `sourceType`, but this one has `None` explicitly allowed in the enum values).

To fix this error, this commit adds `nullable: true` for the attributes `ingestionStatus` and `twincacheStatus` in the openapi.yaml file.