### PR TITLE
Clean deploy test pods automatically on success

### DIFF
--- a/api/kubernetes/helm-chart/templates/tests/test-access-openapi.yaml
+++ b/api/kubernetes/helm-chart/templates/tests/test-access-openapi.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     email: "platform@cosmotech.com"
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     "ignore-check.kube-linter.io/no-liveness-probe": "This is a one-shot pod for testing. It is not supposed to run forever."
     "ignore-check.kube-linter.io/no-readiness-probe": "This is a one-shot pod for testing. It is not supposed to run forever."
     "ignore-check.kube-linter.io/default-service-account": "This is a one-shot pod for testing."

--- a/api/kubernetes/helm-chart/templates/tests/test-access-swaggerui.yaml
+++ b/api/kubernetes/helm-chart/templates/tests/test-access-swaggerui.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     email: "platform@cosmotech.com"
     "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
     "ignore-check.kube-linter.io/no-liveness-probe": "This is a one-shot pod for testing. It is not supposed to run forever."
     "ignore-check.kube-linter.io/no-readiness-probe": "This is a one-shot pod for testing. It is not supposed to run forever."
     "ignore-check.kube-linter.io/default-service-account": "This is a one-shot pod for testing."


### PR DESCRIPTION
No need to keep successful stopped pods cluttering the cluster