### PR TITLE
remove restriction on dataset twincache manipulation

### DIFF
--- a/dataset/src/integrationTest/kotlin/com/cosmotech/dataset/service/DatasetServiceIntegrationTest.kt
+++ b/dataset/src/integrationTest/kotlin/com/cosmotech/dataset/service/DatasetServiceIntegrationTest.kt
@@ -598,7 +598,6 @@ class DatasetServiceIntegrationTest : CsmRedisTestBase() {
 
     val modifiedDataset =
         datasetApiService.findDatasetById(organizationSaved.id!!, datasetSaved.id!!)
-    assertEquals(Dataset.IngestionStatus.SUCCESS.value, modifiedDataset.ingestionStatus!!.value)
     assertEquals(Dataset.TwincacheStatus.FULL.value, modifiedDataset.twincacheStatus!!.value)
   }
 


### PR DESCRIPTION
This come for easing the manipulation of dataset twincache in ETL. Upload can now be done for every sourceType not just File type. Trx (transaction) has been removed from crud for twincache entities.