### PR TITLE
fix generated connector name to simplify redis search

### DIFF
--- a/dataset/src/integrationTest/kotlin/com/cosmotech/dataset/service/DatasetServiceIntegrationTest.kt
+++ b/dataset/src/integrationTest/kotlin/com/cosmotech/dataset/service/DatasetServiceIntegrationTest.kt
@@ -888,6 +888,15 @@ class DatasetServiceIntegrationTest : CsmRedisTestBase() {
             .linkedDatasetIdList)
   }
 
+  @Test
+  fun `getConnector return same connector`() {
+    val dataset = makeDatasetWithRole()
+    val dataset1 = datasetApiService.createDataset(organizationSaved.id!!, dataset)
+    val dataset2 = datasetApiService.createDataset(organizationSaved.id!!, dataset)
+
+    assertEquals(dataset1.connector!!.id, dataset2.connector!!.id)
+  }
+
   fun makeConnector(): Connector {
     return Connector(
         key = "connector",

--- a/dataset/src/main/kotlin/com/cosmotech/dataset/service/DatasetServiceImpl.kt
+++ b/dataset/src/main/kotlin/com/cosmotech/dataset/service/DatasetServiceImpl.kt
@@ -1116,8 +1116,7 @@ class DatasetServiceImpl(
         csmPlatformProperties.containers.find { it.name == TWINCACHE_CONNECTOR }
             ?: throw CsmResourceNotFoundException(
                 "Connector $TWINCACHE_CONNECTOR not found in application.yml")
-    val connectorName =
-        twinCacheConnectorProperties.name + " " + twinCacheConnectorProperties.imageVersion
+    val connectorName = "PlatformGenerated" + twinCacheConnectorProperties.name
     try {
       return connectorService.findConnectorByName(connectorName)
     } catch (exception: CsmClientException) {


### PR DESCRIPTION
Redis search have a hard time with dot(.)