### PR TITLE
Add comment on database creation

### DIFF
--- a/run/src/main/kotlin/com/cosmotech/run/config/RunStorageConfig.kt
+++ b/run/src/main/kotlin/com/cosmotech/run/config/RunStorageConfig.kt
@@ -54,8 +54,10 @@ fun JdbcTemplate.existTable(name: String): Boolean {
 fun String.toDataTableName(isProbeData: Boolean): String =
     if (isProbeData) "P_$this" else "CD_$this"
 
-fun JdbcTemplate.createDB(name: String): String {
+fun JdbcTemplate.createDB(name: String, comment: String? = null): String {
   this.execute("CREATE DATABASE \"$name\"")
+  if (comment != null)
+    this.execute("COMMENT ON DATABASE \"$name\" IS `$comment`")
   return name
 }
 

--- a/run/src/main/kotlin/com/cosmotech/run/service/RunServiceImpl.kt
+++ b/run/src/main/kotlin/com/cosmotech/run/service/RunServiceImpl.kt
@@ -436,7 +436,9 @@ class RunServiceImpl(
     val runId = idGenerator.generate("run", prependPrefix = "run-")
 
     if (csmPlatformProperties.internalResultServices?.enabled == true) {
-      adminRunStorageTemplate.createDB(runId)
+      val dbComment =
+          "organizationId=${runner.organizationId!!}, workspaceId=${runner.workspaceId!!}, runnerId=${runner.id!!}"
+      adminRunStorageTemplate.createDB(runId, dbComment)
 
       val runtimeDS =
           DriverManagerDataSource(


### PR DESCRIPTION
This allow to add runner metadata on the database itself making it easier to debug future issues where only the run id is given

(direct connection to the postgresql instance and use of \l+ will show the comments)