### PR TITLE
Return twingraph query results as json list

### DIFF
--- a/dataset/src/integrationTest/kotlin/com/cosmotech/dataset/service/DatasetServiceIntegrationTest.kt
+++ b/dataset/src/integrationTest/kotlin/com/cosmotech/dataset/service/DatasetServiceIntegrationTest.kt
@@ -703,10 +703,9 @@ class DatasetServiceIntegrationTest : CsmRedisTestBase() {
         datasetSaved.id!!,
         "node",
         listOf(GraphProperties(type = "Node", name = "newNode", params = "value:0")))
-    var queryResult =
+    val queryResult =
         datasetApiService.twingraphQuery(
             organizationSaved.id!!, datasetSaved.id!!, DatasetTwinGraphQuery("MATCH (n) RETURN n"))
-    val initalNodeAmount = queryResult.split("}}}").size
 
     datasetApiService.uploadTwingraph(organizationSaved.id!!, datasetSaved.id!!, resource)
     do {
@@ -714,12 +713,11 @@ class DatasetServiceIntegrationTest : CsmRedisTestBase() {
     } while (datasetApiService.getDatasetTwingraphStatus(
         organizationSaved.id!!, datasetSaved.id!!) == IngestionStatusEnum.PENDING.value)
 
-    queryResult =
+    val secondQueryResult =
         datasetApiService.twingraphQuery(
             organizationSaved.id!!, datasetSaved.id!!, DatasetTwinGraphQuery("MATCH (n) RETURN n"))
-    val newNodeAmount = queryResult.split("}}}").size
 
-    assertNotEquals(initalNodeAmount, newNodeAmount)
+    assertNotEquals(queryResult.size, secondQueryResult.size)
   }
 
   @Test

--- a/dataset/src/main/kotlin/com/cosmotech/dataset/service/DatasetServiceImpl.kt
+++ b/dataset/src/main/kotlin/com/cosmotech/dataset/service/DatasetServiceImpl.kt
@@ -76,6 +76,8 @@ import com.cosmotech.dataset.utils.toCsmGraphEntity
 import com.cosmotech.dataset.utils.toJsonString
 import com.cosmotech.organization.OrganizationApiServiceInterface
 import com.cosmotech.organization.service.getRbac
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import java.io.InputStream
 import java.nio.charset.StandardCharsets
 import java.time.Instant
@@ -617,10 +619,13 @@ class DatasetServiceImpl(
       organizationId: String,
       datasetId: String,
       datasetTwinGraphQuery: DatasetTwinGraphQuery
-  ): String {
+  ): List<Any> {
     val dataset =
         getDatasetWithStatus(organizationId, datasetId, status = IngestionStatusEnum.SUCCESS)
-    return query(dataset, datasetTwinGraphQuery.query).toJsonString()
+
+    val gson = Gson()
+    val mapAdapter = gson.getAdapter(object : TypeToken<List<Any>>() {})
+    return mapAdapter.fromJson(query(dataset, datasetTwinGraphQuery.query).toJsonString())
   }
 
   override fun query(dataset: Dataset, query: String, isReadOnly: Boolean): ResultSet {

--- a/dataset/src/main/openapi/dataset.yaml
+++ b/dataset/src/main/openapi/dataset.yaml
@@ -462,7 +462,9 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                type: array
+                items:
+                  type: object
 
   /organizations/{organization_id}/datasets/{dataset_id}/twingraph/{type}:
     parameters:

--- a/doc/Apis/DatasetApi.md
+++ b/doc/Apis/DatasetApi.md
@@ -730,7 +730,7 @@ Async batch update by loading a CSV file on a graph instance
 
 <a name="twingraphQuery"></a>
 # **twingraphQuery**
-> String twingraphQuery(organization\_id, dataset\_id, DatasetTwinGraphQuery)
+> List twingraphQuery(organization\_id, dataset\_id, DatasetTwinGraphQuery)
 
 Return the result of a query made on the graph instance as a json
 
@@ -746,7 +746,7 @@ Return the result of a query made on the graph instance as a json
 
 ### Return type
 
-**String**
+**List**
 
 ### Authorization
 


### PR DESCRIPTION
Update return type of `dataset/twingraphQuery` to list

This update allows a cleaner explanation of the return type as Cypher queries return list of results

Also this should update the API libraries generated so that there is no need to do user based operation on the return value.

No more need to convert the returned string to working types using external libraries.
