### PR TITLE
[PROD-13427][PROD-13433] Update k8s client to 21.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,7 @@ val swaggerParserVersion = "2.1.22"
 val commonsCsvVersion = "1.10.0"
 val apiValidationVersion = "3.0.2"
 val awsSpringVersion = "3.1.1"
+val kubernetesClientVersion = "21.0.0"
 
 // Checks
 val detektVersion = "1.23.5"
@@ -282,6 +283,7 @@ subprojects {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     // https://mvnrepository.com/artifact/jakarta.validation/jakarta.validation-api
     implementation("jakarta.validation:jakarta.validation-api:$apiValidationVersion")
+    implementation("io.kubernetes:client-java:${kubernetesClientVersion}")
 
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${springDocVersion}")
     implementation("io.swagger.parser.v3:swagger-parser-v3:${swaggerParserVersion}")

--- a/run/src/main/kotlin/com/cosmotech/run/workflow/argo/WorkflowBuilders.kt
+++ b/run/src/main/kotlin/com/cosmotech/run/workflow/argo/WorkflowBuilders.kt
@@ -32,6 +32,7 @@ import io.kubernetes.client.openapi.models.V1ResourceRequirements
 import io.kubernetes.client.openapi.models.V1Toleration
 import io.kubernetes.client.openapi.models.V1Volume
 import io.kubernetes.client.openapi.models.V1VolumeMount
+import io.kubernetes.client.openapi.models.V1VolumeResourceRequirements
 
 private const val CSM_DAG_ENTRYPOINT = "entrypoint"
 private const val CSM_DEFAULT_WORKFLOW_NAME = "default-workflow-"
@@ -202,7 +203,7 @@ private fun buildVolumeClaims(
                       if (workflowsConfig.storageClass.isNullOrBlank()) null
                       else workflowsConfig.storageClass)
                   .resources(
-                      V1ResourceRequirements()
+                      V1VolumeResourceRequirements()
                           .requests(workflowsConfig.requests.mapValues { Quantity(it.value) })))
   return listOf(dataDir)
 }

--- a/run/src/test/kotlin/com/cosmotech/run/workflow/argo/WorkflowBuildersTests.kt
+++ b/run/src/test/kotlin/com/cosmotech/run/workflow/argo/WorkflowBuildersTests.kt
@@ -11,8 +11,8 @@ import io.kubernetes.client.openapi.models.V1EnvVar
 import io.kubernetes.client.openapi.models.V1ObjectMeta
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaim
 import io.kubernetes.client.openapi.models.V1PersistentVolumeClaimSpec
-import io.kubernetes.client.openapi.models.V1ResourceRequirements
 import io.kubernetes.client.openapi.models.V1VolumeMount
+import io.kubernetes.client.openapi.models.V1VolumeResourceRequirements
 import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.BeforeTest
@@ -388,7 +388,7 @@ class WorkflowBuildersTests {
   fun `Create Workflow with StartContainers generate name default`() {
     val sc = getStartContainers()
     val workflow = buildWorkflow(csmPlatformProperties, sc, null)
-    val expected = V1ObjectMeta().generateName("default-workflow-")
+    val expected = V1ObjectMeta().generateName("default-workflow-").labels(null)
     assertEquals(expected, workflow.metadata)
   }
 
@@ -396,7 +396,7 @@ class WorkflowBuildersTests {
   fun `Create Workflow with StartContainers generate name Scenario`() {
     val sc = getStartContainersNamed()
     val workflow = buildWorkflow(csmPlatformProperties, sc, null)
-    val expected = V1ObjectMeta().generateName("Scenario-1-")
+    val expected = V1ObjectMeta().generateName("Scenario-1-").labels(null)
     assertEquals(expected, workflow.metadata)
   }
 
@@ -411,7 +411,7 @@ class WorkflowBuildersTests {
                 V1PersistentVolumeClaimSpec()
                     .accessModes(emptyList())
                     .storageClassName(null)
-                    .resources(V1ResourceRequirements().requests(emptyMap())))
+                    .resources(V1VolumeResourceRequirements().requests(emptyMap())))
     val expected = listOf(dataDir)
     assertEquals(expected, workflowSpec.volumeClaimTemplates)
   }
@@ -431,7 +431,8 @@ class WorkflowBuildersTests {
                     .accessModes(listOf("ReadWriteMany"))
                     .storageClassName("cosmotech-api-test-phoenix")
                     .resources(
-                        V1ResourceRequirements().requests(mapOf("storage" to Quantity("300Gi")))))
+                        V1VolumeResourceRequirements()
+                            .requests(mapOf("storage" to Quantity("300Gi")))))
     val expected = listOf(dataDir)
     assertEquals(expected, workflowSpec.volumeClaimTemplates)
   }

--- a/workspace/src/main/kotlin/com/cosmotech/workspace/service/WorkspaceServiceImpl.kt
+++ b/workspace/src/main/kotlin/com/cosmotech/workspace/service/WorkspaceServiceImpl.kt
@@ -183,7 +183,7 @@ internal class WorkspaceServiceImpl(
     try {
       deleteAllS3WorkspaceObjects(organizationId, workspace)
       secretManager.deleteSecret(
-          csmPlatformProperties.namespace, getWorkspaceSecretName(organizationId, workspace.key))
+          csmPlatformProperties.namespace, getWorkspaceSecretName(organizationId, workspaceId))
 
       workspace.linkedDatasetIdList?.forEach { unlinkDataset(organizationId, workspaceId, it) }
     } finally {
@@ -284,10 +284,10 @@ internal class WorkspaceServiceImpl(
       workspaceId: String,
       workspaceSecret: WorkspaceSecret
   ) {
-    val workspaceKey = getVerifiedWorkspace(organizationId, workspaceId).key
+    getVerifiedWorkspace(organizationId, workspaceId)
     secretManager.createOrReplaceSecret(
         csmPlatformProperties.namespace,
-        getWorkspaceSecretName(organizationId, workspaceKey),
+        getWorkspaceSecretName(organizationId, workspaceId),
         mapOf(WORKSPACE_EVENTHUB_ACCESSKEY_SECRET to (workspaceSecret.dedicatedEventHubKey ?: "")))
   }
 


### PR DESCRIPTION
Somehow, the current version was generating timeouts

This will need to be backported to versions 3.2+