### PR TITLE
[PROD-13427][PROD-13433] Use workspace id to read the secret

### DIFF
--- a/workspace/src/main/kotlin/com/cosmotech/workspace/azure/strategy/WorkspaceEventHubStrategyDedicated.kt
+++ b/workspace/src/main/kotlin/com/cosmotech/workspace/azure/strategy/WorkspaceEventHubStrategyDedicated.kt
@@ -29,7 +29,7 @@ class WorkspaceEventHubStrategyDedicated(
       organizationId: String,
       workspace: Workspace,
   ): String {
-    val secretName = getWorkspaceSecretName(organizationId, workspace.key)
+    val secretName = getWorkspaceSecretName(organizationId, workspace.id!!)
     val secretData = secretManager.readSecret(csmPlatformProperties.namespace, secretName)
     return secretData[WORKSPACE_EVENTHUB_ACCESSKEY_SECRET]
         ?: throw IllegalStateException(

--- a/workspace/src/main/kotlin/com/cosmotech/workspace/utils/WorkspaceUtils.kt
+++ b/workspace/src/main/kotlin/com/cosmotech/workspace/utils/WorkspaceUtils.kt
@@ -2,8 +2,8 @@
 // Licensed under the MIT license.
 package com.cosmotech.workspace.utils
 
-fun getWorkspaceSecretName(organizationId: String, workspaceKey: String) =
-    getWorkspaceUniqueName(organizationId, workspaceKey)
+fun getWorkspaceSecretName(organizationId: String, workspaceId: String) =
+    getWorkspaceUniqueName(organizationId, workspaceId)
 
 fun getWorkspaceUniqueName(organizationId: String, workspaceKey: String) =
     "$organizationId-$workspaceKey".lowercase()


### PR DESCRIPTION
This was missed in the recent commit that changed the secret name pattern