### PR TITLE
Improve usage of container registry config

### DIFF
--- a/api/kubernetes/helm-chart/values-azure.yaml
+++ b/api/kubernetes/helm-chart/values-azure.yaml
@@ -64,6 +64,3 @@ config:
             ingestionUri: "https://changeme.kusto.windows.net"
         eventBus:
           baseUri: "amqps://changeme.servicebus.windows.net"
-      containerRegistry:
-        provider: azure
-        registryUrl: "https://changeme.azurecr.io"

--- a/api/kubernetes/helm-chart/values-dev.yaml
+++ b/api/kubernetes/helm-chart/values-dev.yaml
@@ -49,7 +49,3 @@ config:
             - ReadWriteOnce
           requests:
             storage: 1Gi
-      containerRegistry:
-        registryUrl: "https://csmenginesdev.azurecr.io"
-        registryUserName: "user-name"
-        registryPassword: "a-super-secret-password"

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -170,12 +170,10 @@ csm:
       # duration in days to query logs
       queryDaysAgo: 1
     containerRegistry:
-      # azure or local
-      provider: local
-      # https://csmenginesdev.azurecr.io or localhost:5000
-      registryUrl: localhost:5000
-      registryUserName: csmenginesdev
-      registryPassword: "my_registry_password"
+      scheme: http
+      host: localhost:5000
+      username: csmenginesdev
+      password: "my_registry_password"
 
 springdoc:
   # See https://springdoc.org/#properties

--- a/run/src/integrationTest/resources/application-run-test.yml
+++ b/run/src/integrationTest/resources/application-run-test.yml
@@ -126,9 +126,9 @@ csm:
     rbac:
       enabled: true
     containerRegistry:
-      provider: "local"
-      registryUrl: "http://localhost:5000"
-      registryUserName: "default"
-      registryPassword: "my-wonderful-password"
+      scheme: http
+      host: "localhost:5000"
+      username: "default"
+      password: "my-wonderful-password"
     blobPersistence:
       path: /tmp/cosmotech-api-run-test-data

--- a/run/src/main/kotlin/com/cosmotech/run/RunContainerFactory.kt
+++ b/run/src/main/kotlin/com/cosmotech/run/RunContainerFactory.kt
@@ -171,9 +171,7 @@ class RunContainerFactory(
 
     val imageName =
         getImageName(
-            csmPlatformProperties.containerRegistry.registryUrl,
-            solution.repository,
-            solution.version)
+            csmPlatformProperties.containerRegistry.host, solution.repository, solution.version)
 
     val envVars =
         getCommonEnvVars(

--- a/run/src/test/kotlin/com/cosmotech/run/ContainerFactoryTests.kt
+++ b/run/src/test/kotlin/com/cosmotech/run/ContainerFactoryTests.kt
@@ -83,11 +83,12 @@ class ContainerFactoryTests {
             password = "this_is_a_password",
         )
     every { csmPlatformProperties.containerRegistry } returns
-        CsmPlatformProperties.CsmPlatformContainerRegistries(
-            registryUrl = "twinengines.azurecr.io",
+        CsmPlatformProperties.CsmPlatformContainerRegistry(
+            scheme = "https",
+            host = "twinengines.azurecr.io",
             checkSolutionImage = true,
-            registryPassword = "password",
-            registryUserName = "username")
+            password = "password",
+            username = "username")
 
     every { csmPlatformProperties.internalResultServices } returns
         CsmPlatformProperties.CsmServiceResult(


### PR DESCRIPTION
We need the scheme separate to be able to HTTP query the registry for image existence, but we don't need the scheme for image configuration of the workflow