### PR TITLE
[PROD-13480] Remove the 'findConnectorByName' endpoint

### DIFF
--- a/connector/src/main/kotlin/com/cosmotech/connector/ConnectorApiServiceInterface.kt
+++ b/connector/src/main/kotlin/com/cosmotech/connector/ConnectorApiServiceInterface.kt
@@ -3,5 +3,8 @@
 package com.cosmotech.connector
 
 import com.cosmotech.connector.api.ConnectorApiService
+import com.cosmotech.connector.domain.Connector
 
-interface ConnectorApiServiceInterface : ConnectorApiService
+interface ConnectorApiServiceInterface : ConnectorApiService {
+  fun findConnectorByName(connectorName: String): Connector
+}

--- a/connector/src/main/kotlin/com/cosmotech/connector/service/ConnectorServiceImpl.kt
+++ b/connector/src/main/kotlin/com/cosmotech/connector/service/ConnectorServiceImpl.kt
@@ -39,7 +39,7 @@ class ConnectorServiceImpl(var connectorRepository: ConnectorRepository) :
   override fun findConnectorByName(connectorName: String): Connector {
     return connectorRepository.findFirstByName(connectorName)
         ?: throw CsmResourceNotFoundException(
-            "Resource of type '${Connector::class.java.simpleName}' and identifier '$connectorName' not found")
+            "Resource of type '${Connector::class.java.simpleName}' and name '$connectorName' not found")
   }
 
   override fun registerConnector(connector: Connector): Connector {

--- a/connector/src/main/openapi/connector.yaml
+++ b/connector/src/main/openapi/connector.yaml
@@ -118,29 +118,6 @@ paths:
           description: Request successful
         "404":
           description: the Connector specified is unknown or you don't have access to it
-  /connectors/name/{connector_name}:
-    parameters:
-      - name: connector_name
-        in: path
-        description: the Connector name
-        required: true
-        schema:
-          type: string
-    get:
-      operationId: findConnectorByName
-      tags:
-        - connector
-      summary: Get the details of a connector
-      responses:
-        "200":
-          description: the Connector details
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Connector'
-              examples:
-                ADTConnector:
-                  $ref: '#/components/examples/ADTConnector'
 
 components:
   securitySchemes:

--- a/doc/Apis/ConnectorApi.md
+++ b/doc/Apis/ConnectorApi.md
@@ -6,7 +6,6 @@ All URIs are relative to *https://dev.api.cosmotech.com*
 |------------- | ------------- | -------------|
 | [**findAllConnectors**](ConnectorApi.md#findAllConnectors) | **GET** /connectors | List all Connectors |
 | [**findConnectorById**](ConnectorApi.md#findConnectorById) | **GET** /connectors/{connector_id} | Get the details of a connector |
-| [**findConnectorByName**](ConnectorApi.md#findConnectorByName) | **GET** /connectors/name/{connector_name} | Get the details of a connector |
 | [**registerConnector**](ConnectorApi.md#registerConnector) | **POST** /connectors | Register a new connector |
 | [**unregisterConnector**](ConnectorApi.md#unregisterConnector) | **DELETE** /connectors/{connector_id} | Unregister a connector |
 
@@ -48,31 +47,6 @@ Get the details of a connector
 |Name | Type | Description  | Notes |
 |------------- | ------------- | ------------- | -------------|
 | **connector\_id** | **String**| the Connector identifier | [default to null] |
-
-### Return type
-
-[**Connector**](../Models/Connector.md)
-
-### Authorization
-
-[oAuth2AuthCode](../README.md#oAuth2AuthCode)
-
-### HTTP request headers
-
-- **Content-Type**: Not defined
-- **Accept**: application/json
-
-<a name="findConnectorByName"></a>
-# **findConnectorByName**
-> Connector findConnectorByName(connector\_name)
-
-Get the details of a connector
-
-### Parameters
-
-|Name | Type | Description  | Notes |
-|------------- | ------------- | ------------- | -------------|
-| **connector\_name** | **String**| the Connector name | [default to null] |
 
 ### Return type
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -9,7 +9,6 @@ All URIs are relative to *https://dev.api.cosmotech.com*
 |------------ | ------------- | ------------- | -------------|
 | *ConnectorApi* | [**findAllConnectors**](Apis/ConnectorApi.md#findallconnectors) | **GET** /connectors | List all Connectors |
 *ConnectorApi* | [**findConnectorById**](Apis/ConnectorApi.md#findconnectorbyid) | **GET** /connectors/{connector_id} | Get the details of a connector |
-*ConnectorApi* | [**findConnectorByName**](Apis/ConnectorApi.md#findconnectorbyname) | **GET** /connectors/name/{connector_name} | Get the details of a connector |
 *ConnectorApi* | [**registerConnector**](Apis/ConnectorApi.md#registerconnector) | **POST** /connectors | Register a new connector |
 *ConnectorApi* | [**unregisterConnector**](Apis/ConnectorApi.md#unregisterconnector) | **DELETE** /connectors/{connector_id} | Unregister a connector |
 | *DatasetApi* | [**addDatasetAccessControl**](Apis/DatasetApi.md#adddatasetaccesscontrol) | **POST** /organizations/{organization_id}/datasets/{dataset_id}/security/access | Add a control access to the Dataset |


### PR DESCRIPTION
'-' and some other symbols need to be escaped properly to work with a searchable redis field. However, this endpoint was only added to support a previous migration script and is only used once internally. The internal use does not require this to be a proper endpoint, so we can just make it a method. And the internal use will always look for a fixed connector name that does not exhibit the original search issue.