### PR TITLE
Fix argo volume access mode

### DIFF
--- a/api/kubernetes/helm-chart/README.md
+++ b/api/kubernetes/helm-chart/README.md
@@ -30,7 +30,7 @@ Cosmo Tech Platform API
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
 | autoscaling.targetMemoryUtilizationPercentage | int | `80` |  |
 | config.csm.platform.argo.base-uri | string | `"http://argo-server:2746"` |  |
-| config.csm.platform.argo.workflows.access-modes[0] | string | `"ReadWriteMany"` | Any in the following list: ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod (K8s 1.22+). ReadWriteMany is recommended, as we are likely to have parallel pods accessing the volume |
+| config.csm.platform.argo.workflows.access-modes[0] | string | `"ReadWriteOnce"` | Any in the following list: ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod (K8s 1.22+). |
 | config.csm.platform.argo.workflows.requests.storage | string | `"100Gi"` |  |
 | config.csm.platform.argo.workflows.storage-class | string | `nil` | Name of the storage class for Workflows volumes. Useful if you want to use a different storage class managed externally |
 | config.csm.platform.authorization.allowed-tenants | list | `[]` |  |

--- a/api/kubernetes/helm-chart/values.yaml
+++ b/api/kubernetes/helm-chart/values.yaml
@@ -172,8 +172,7 @@ config:
           storage-class: null
           access-modes:
             # -- Any in the following list: ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod (K8s 1.22+).
-            # ReadWriteMany is recommended, as we are likely to have parallel pods accessing the volume
-            - ReadWriteMany
+            - ReadWriteOnce
           requests:
             # File storage minimal claim is 100Gi for Premium classes
             storage: 100Gi


### PR DESCRIPTION
With the new orchestrator we only have a single pod now, so 'Many' access is not required anymore, this should fix azure deployement where we don't force a 'Many' compatible storage anymore