### PR TITLE
Fix swagger-ui spec display/config

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -186,6 +186,7 @@ springdoc:
   # See https://springdoc.org/#properties
   api-docs:
     path: /openapi
+  packages-to-scan: [""] # Don't load OpenAPI specs from code annotations, we already load the merged file
   pre-loading-enabled: true
   remove-broken-reference-definitions: false
   show-actuator: false


### PR DESCRIPTION
Disable code scanning, it conflicts with our own merge spec config