### PR TITLE
Put back the OAuth config in the OpenAPI spec

### DIFF
--- a/connector/src/main/openapi/connector.yaml
+++ b/connector/src/main/openapi/connector.yaml
@@ -4,6 +4,9 @@ info:
   title: ""
   version: ""
 
+security:
+  - oAuth2AuthCode: []
+
 tags:
 - name: connector
   description: Connector Management
@@ -117,10 +120,10 @@ components:
       type: oauth2
       description: OAuth2 authentication
       flows:
-        implicit:
-          authorizationUrl: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          scopes:
-            http://dev.api.cosmotech.com/platform: Platform scope
+        authorizationCode:
+          authorizationUrl: "https://example.com/authorize"
+          tokenUrl: "https://example.com/token"
+          scopes: {}
   schemas:
     Connector:
       type: object

--- a/dataset/src/main/openapi/dataset.yaml
+++ b/dataset/src/main/openapi/dataset.yaml
@@ -4,6 +4,9 @@ info:
   title: ""
   version: ""
 
+security:
+  - oAuth2AuthCode: []
+
 tags:
   - name: dataset
     description: Dataset Management
@@ -1143,10 +1146,10 @@ components:
       type: oauth2
       description: OAuth2 authentication
       flows:
-        implicit:
-          authorizationUrl: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          scopes:
-            http://dev.api.cosmotech.com/platform: Platform scope
+        authorizationCode:
+          authorizationUrl: "https://example.com/authorize"
+          tokenUrl: "https://example.com/token"
+          scopes: {}
   schemas:
     FileUploadValidation:
       type: object

--- a/doc/Apis/ConnectorApi.md
+++ b/doc/Apis/ConnectorApi.md
@@ -29,7 +29,7 @@ List all Connectors
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -54,7 +54,7 @@ Get the details of a connector
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -79,7 +79,7 @@ Register a new connector
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -104,7 +104,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 

--- a/doc/Apis/DatasetApi.md
+++ b/doc/Apis/DatasetApi.md
@@ -57,7 +57,7 @@ Add a control access to the Dataset
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -84,7 +84,7 @@ Add Dataset Compatibility elements.
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -112,7 +112,7 @@ Copy a Dataset to another Dataset.
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -138,7 +138,7 @@ Create a new Dataset
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -167,7 +167,7 @@ Create a sub-dataset from the dataset in parameter
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -197,7 +197,7 @@ Create new entities in a graph instance
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -223,7 +223,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -253,7 +253,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -281,7 +281,7 @@ Download a graph as a zip file
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -308,7 +308,7 @@ List all Datasets
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -334,7 +334,7 @@ Get the details of a Dataset
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -361,7 +361,7 @@ Get a control access for the Dataset
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -387,7 +387,7 @@ Get the Dataset security information
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -413,7 +413,7 @@ Get the Dataset security users list
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -441,7 +441,7 @@ Get the dataset&#39;s refresh job status
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -471,7 +471,7 @@ Get entities in a graph instance
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -498,7 +498,7 @@ No authorization required
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -526,7 +526,7 @@ Refresh data on dataset from dataset&#39;s source
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -552,7 +552,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -579,7 +579,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -607,7 +607,7 @@ Rollback the dataset after a failed refresh
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -635,7 +635,7 @@ Search Datasets by tags
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -662,7 +662,7 @@ Set the Dataset default security
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -691,7 +691,7 @@ Run a query on a graph instance and return the result as a zip file in async mod
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -721,7 +721,7 @@ Async batch update by loading a CSV file on a graph instance
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -750,7 +750,7 @@ Return the result of a query made on the graph instance as a json
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -777,7 +777,7 @@ No authorization required
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -804,7 +804,7 @@ Update a dataset
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -832,7 +832,7 @@ Update the specified access to User for a Dataset
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -862,7 +862,7 @@ Update entities in a graph instance
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -891,7 +891,7 @@ Upload data from zip file to dataset&#39;s twingraph
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 

--- a/doc/Apis/OrganizationApi.md
+++ b/doc/Apis/OrganizationApi.md
@@ -39,7 +39,7 @@ Add a control access to the Organization
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -65,7 +65,7 @@ List all Organizations
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -90,7 +90,7 @@ Get the details of an Organization
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -112,7 +112,7 @@ This endpoint does not need any parameter.
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -138,7 +138,7 @@ Get a control access for the Organization
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -164,7 +164,7 @@ Get the Organization permissions by given role
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -189,7 +189,7 @@ Get the Organization security information
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -214,7 +214,7 @@ Get the Organization security users list
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -239,7 +239,7 @@ Register a new organization
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -265,7 +265,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -291,7 +291,7 @@ Set the Organization default security
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -316,7 +316,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -342,7 +342,7 @@ Update an Organization
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -369,7 +369,7 @@ Update the specified access to User for an Organization
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 

--- a/doc/Apis/RunApi.md
+++ b/doc/Apis/RunApi.md
@@ -34,7 +34,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -62,7 +62,7 @@ Get the details of a run
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -90,7 +90,7 @@ get the logs for the Run
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -118,7 +118,7 @@ get the status for the Run
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -147,7 +147,7 @@ get the list of Runs for the Runner
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -176,7 +176,7 @@ query the run data
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -205,7 +205,7 @@ Send data associated to a run
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 

--- a/doc/Apis/RunnerApi.md
+++ b/doc/Apis/RunnerApi.md
@@ -42,7 +42,7 @@ Add a control access to the Runner
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -69,7 +69,7 @@ Create a new Runner
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -96,7 +96,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -123,7 +123,7 @@ Get the details of an runner
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -151,7 +151,7 @@ Get a control access for the Runner
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -179,7 +179,7 @@ Get the Runner permission by given role
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -206,7 +206,7 @@ Get the Runner security information
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -233,7 +233,7 @@ Get the Runner security users list
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -261,7 +261,7 @@ List all Runners
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -289,7 +289,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -317,7 +317,7 @@ Set the Runner default security
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -344,7 +344,7 @@ Start a run with runner parameters
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -371,7 +371,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -399,7 +399,7 @@ Update a runner
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -428,7 +428,7 @@ Update the specified access to User for a Runner
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 

--- a/doc/Apis/SolutionApi.md
+++ b/doc/Apis/SolutionApi.md
@@ -46,7 +46,7 @@ Add Parameter Groups. Any item with the same ID will be overwritten
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -73,7 +73,7 @@ Add Parameters. Any item with the same ID will be overwritten
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -100,7 +100,7 @@ Add Run Templates. Any item with the same ID will be overwritten
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -127,7 +127,7 @@ Add a control access to the Solution
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -153,7 +153,7 @@ Register a new solution
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -179,7 +179,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -206,7 +206,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -233,7 +233,7 @@ List all Solutions
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -259,7 +259,7 @@ Get the details of a solution
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -286,7 +286,7 @@ Get a control access for the Solution
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -312,7 +312,7 @@ Get the Solution security information
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -338,7 +338,7 @@ Get the Solution security users list
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -364,7 +364,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -390,7 +390,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -416,7 +416,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -443,7 +443,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -470,7 +470,7 @@ Set the Solution default security
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -497,7 +497,7 @@ Update a solution
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -525,7 +525,7 @@ Update the specified access to User for a Solution
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -553,7 +553,7 @@ Update the specified Solution Run Template
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 

--- a/doc/Apis/WorkspaceApi.md
+++ b/doc/Apis/WorkspaceApi.md
@@ -46,7 +46,7 @@ Add a control access to the Workspace
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -72,7 +72,7 @@ Create a new workspace
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -98,7 +98,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -124,7 +124,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -151,7 +151,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -178,7 +178,7 @@ Download the Workspace File specified
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -204,7 +204,7 @@ List all Workspace files
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -231,7 +231,7 @@ List all Workspaces
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -257,7 +257,7 @@ Get the details of an workspace
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -284,7 +284,7 @@ Get a control access for the Workspace
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -311,7 +311,7 @@ Get the Workspace permission by given role
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -337,7 +337,7 @@ Get the Workspace security information
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -363,7 +363,7 @@ Get the Workspace security users list
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -390,7 +390,7 @@ No authorization required
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -417,7 +417,7 @@ null (empty response body)
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -444,7 +444,7 @@ Set the Workspace default security
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -471,7 +471,7 @@ No authorization required
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -498,7 +498,7 @@ Update a workspace
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -526,7 +526,7 @@ Update the specified access to User for a Workspace
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 
@@ -555,7 +555,7 @@ Upload a file for the Workspace
 
 ### Authorization
 
-No authorization required
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
 
 ### HTTP request headers
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -202,8 +202,7 @@ All URIs are relative to *http://localhost*
 ### oAuth2AuthCode
 
 - **Type**: OAuth
-- **Flow**: implicit
-- **Authorization URL**: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
-- **Scopes**: 
-  - http://dev.api.cosmotech.com/platform: Platform scope
+- **Flow**: accessCode
+- **Authorization URL**: https://example.com/authorize
+- **Scopes**: N/A
 

--- a/organization/src/main/openapi/organization.yaml
+++ b/organization/src/main/openapi/organization.yaml
@@ -4,6 +4,9 @@ info:
   title: ""
   version: ""
 
+security:
+  - oAuth2AuthCode: []
+
 tags:
 - name: organization
   description: Organization Management
@@ -423,10 +426,10 @@ components:
       type: oauth2
       description: OAuth2 authentication
       flows:
-        implicit:
-          authorizationUrl: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          scopes:
-            http://dev.api.cosmotech.com/platform: Platform scope
+        authorizationCode:
+          authorizationUrl: "https://example.com/authorize"
+          tokenUrl: "https://example.com/token"
+          scopes: {}
   schemas:
     Organization:
       type: object

--- a/run/src/main/openapi/run.yaml
+++ b/run/src/main/openapi/run.yaml
@@ -4,6 +4,9 @@ info:
   title: ""
   version: ""
 
+security:
+  - oAuth2AuthCode: []
+
 tags:
   - name: run
     description: Run Management
@@ -310,10 +313,10 @@ components:
       type: oauth2
       description: OAuth2 authentication
       flows:
-        implicit:
-          authorizationUrl: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          scopes:
-            http://dev.api.cosmotech.com/platform: Platform scope
+        authorizationCode:
+          authorizationUrl: "https://example.com/authorize"
+          tokenUrl: "https://example.com/token"
+          scopes: {}
   schemas:
     RunData:
       type: object

--- a/runner/src/main/openapi/runner.yaml
+++ b/runner/src/main/openapi/runner.yaml
@@ -4,6 +4,9 @@ info:
   title: ""
   version: ""
 
+security:
+  - oAuth2AuthCode: []
+
 tags:
 - name: runner
   description: Runner Management
@@ -568,10 +571,10 @@ components:
       type: oauth2
       description: OAuth2 authentication
       flows:
-        implicit:
-          authorizationUrl: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          scopes:
-            http://dev.api.cosmotech.com/platform: Platform scope
+        authorizationCode:
+          authorizationUrl: "https://example.com/authorize"
+          tokenUrl: "https://example.com/token"
+          scopes: {}
   schemas:
     Runner:
       type: object

--- a/solution/src/main/openapi/solution.yaml
+++ b/solution/src/main/openapi/solution.yaml
@@ -4,6 +4,9 @@ info:
   title: ""
   version: ""
 
+security:
+  - oAuth2AuthCode: []
+
 tags:
 - name: solution
   description: Solution Management
@@ -615,10 +618,10 @@ components:
       type: oauth2
       description: OAuth2 authentication
       flows:
-        implicit:
-          authorizationUrl: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          scopes:
-            http://dev.api.cosmotech.com/platform: Platform scope
+        authorizationCode:
+          authorizationUrl: "https://example.com/authorize"
+          tokenUrl: "https://example.com/token"
+          scopes: {}
   schemas:
     Solution:
       type: object

--- a/workspace/src/main/openapi/workspace.yaml
+++ b/workspace/src/main/openapi/workspace.yaml
@@ -4,6 +4,9 @@ info:
   title: ""
   version: ""
 
+security:
+  - oAuth2AuthCode: []
+
 tags:
 - name: workspace
   description: Workspace Management
@@ -705,10 +708,10 @@ components:
       type: oauth2
       description: OAuth2 authentication
       flows:
-        implicit:
-          authorizationUrl: https://login.microsoftonline.com/common/oauth2/v2.0/authorize
-          scopes:
-            http://dev.api.cosmotech.com/platform: Platform scope
+        authorizationCode:
+          authorizationUrl: "https://example.com/authorize"
+          tokenUrl: "https://example.com/token"
+          scopes: {}
   schemas:
     Workspace:
       type: object


### PR DESCRIPTION
This is required for a proper config of Swagger and the clients