### PR TITLE
[PROD-13633] Make startRun return a proper object

### DIFF
--- a/doc/.openapi-generator/FILES
+++ b/doc/.openapi-generator/FILES
@@ -11,6 +11,7 @@ Models/ConnectorParameter.md
 Models/ConnectorParameterGroup.md
 Models/ContainerResourceSizeInfo.md
 Models/ContainerResourceSizing.md
+Models/CreatedRun.md
 Models/Dataset.md
 Models/DatasetAccessControl.md
 Models/DatasetCompatibility.md

--- a/doc/Apis/RunnerApi.md
+++ b/doc/Apis/RunnerApi.md
@@ -326,7 +326,7 @@ Set the Runner default security
 
 <a name="startRun"></a>
 # **startRun**
-> String startRun(organization\_id, workspace\_id, runner\_id)
+> CreatedRun startRun(organization\_id, workspace\_id, runner\_id)
 
 Start a run with runner parameters
 
@@ -340,7 +340,7 @@ Start a run with runner parameters
 
 ### Return type
 
-**String**
+[**CreatedRun**](../Models/CreatedRun.md)
 
 ### Authorization
 
@@ -349,7 +349,7 @@ Start a run with runner parameters
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: text/plain
+- **Accept**: application/json
 
 <a name="stopRun"></a>
 # **stopRun**

--- a/doc/Models/CreatedRun.md
+++ b/doc/Models/CreatedRun.md
@@ -1,0 +1,9 @@
+# CreatedRun
+## Properties
+
+| Name | Type | Description | Notes |
+|------------ | ------------- | ------------- | -------------|
+| **id** | **String** | Run id | [default to null] |
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+

--- a/doc/README.md
+++ b/doc/README.md
@@ -129,6 +129,7 @@ All URIs are relative to *http://localhost*
  - [ConnectorParameterGroup](./Models/ConnectorParameterGroup.md)
  - [ContainerResourceSizeInfo](./Models/ContainerResourceSizeInfo.md)
  - [ContainerResourceSizing](./Models/ContainerResourceSizing.md)
+ - [CreatedRun](./Models/CreatedRun.md)
  - [Dataset](./Models/Dataset.md)
  - [DatasetAccessControl](./Models/DatasetAccessControl.md)
  - [DatasetCompatibility](./Models/DatasetCompatibility.md)

--- a/openapi/plantuml/schemas.plantuml
+++ b/openapi/plantuml/schemas.plantuml
@@ -46,6 +46,10 @@ entity ContainerResourceSizing {
     * limits: ContainerResourceSizeInfo
 }
 
+entity CreatedRun {
+    * id: String
+}
+
 entity Dataset {
     id: String
     name: String

--- a/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceIntegrationTest.kt
+++ b/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceIntegrationTest.kt
@@ -659,9 +659,9 @@ class RunnerServiceIntegrationTest : CsmRedisTestBase() {
           firstArg<RunStart>().response = expectedRunId
         }
 
-    val runId =
+    val run =
         runnerApiService.startRun(organizationSaved.id!!, workspaceSaved.id!!, runnerSaved.id!!)
-    assertEquals(expectedRunId, runId)
+    assertEquals(expectedRunId, run.id)
 
     val lastRunId =
         runnerApiService

--- a/runner/src/main/kotlin/com/cosmotech/runner/service/RunnerApiServiceImpl.kt
+++ b/runner/src/main/kotlin/com/cosmotech/runner/service/RunnerApiServiceImpl.kt
@@ -12,6 +12,7 @@ import com.cosmotech.api.rbac.PERMISSION_WRITE_SECURITY
 import com.cosmotech.api.rbac.getRunnerRolesDefinition
 import com.cosmotech.api.utils.constructPageRequest
 import com.cosmotech.runner.RunnerApiServiceInterface
+import com.cosmotech.runner.domain.CreatedRun
 import com.cosmotech.runner.domain.Runner
 import com.cosmotech.runner.domain.RunnerAccessControl
 import com.cosmotech.runner.domain.RunnerRole
@@ -85,7 +86,7 @@ internal class RunnerApiServiceImpl(
     return runnerService.listInstances(pageRequest)
   }
 
-  override fun startRun(organizationId: String, workspaceId: String, runnerId: String): String {
+  override fun startRun(organizationId: String, workspaceId: String, runnerId: String): CreatedRun {
     val runnerService = getRunnerService().inOrganization(organizationId).inWorkspace(workspaceId)
 
     val runnerInstance = runnerService.getInstance(runnerId).userHasPermission(PERMISSION_LAUNCH)

--- a/runner/src/main/kotlin/com/cosmotech/runner/service/RunnerEventServiceImpl.kt
+++ b/runner/src/main/kotlin/com/cosmotech/runner/service/RunnerEventServiceImpl.kt
@@ -15,7 +15,7 @@ class RunnerEventServiceImpl(private val runnerApiService: RunnerApiService) :
     val workspaceId = triggerEvent.workspaceId
     val runnerId = triggerEvent.runnerId
 
-    val runId = runnerApiService.startRun(organizationId, workspaceId, runnerId)
-    triggerEvent.response = runId
+    val run = runnerApiService.startRun(organizationId, workspaceId, runnerId)
+    triggerEvent.response = run.id
   }
 }

--- a/runner/src/main/kotlin/com/cosmotech/runner/service/RunnerService.kt
+++ b/runner/src/main/kotlin/com/cosmotech/runner/service/RunnerService.kt
@@ -27,6 +27,7 @@ import com.cosmotech.dataset.domain.DatasetRole
 import com.cosmotech.dataset.service.getRbac
 import com.cosmotech.organization.OrganizationApiServiceInterface
 import com.cosmotech.organization.domain.Organization
+import com.cosmotech.runner.domain.CreatedRun
 import com.cosmotech.runner.domain.Runner
 import com.cosmotech.runner.domain.RunnerAccessControl
 import com.cosmotech.runner.domain.RunnerRunTemplateParameterValue
@@ -123,13 +124,13 @@ class RunnerService(
         .toList()
   }
 
-  fun startRunWith(runnerInstance: RunnerInstance): String {
+  fun startRunWith(runnerInstance: RunnerInstance): CreatedRun {
     val startEvent = RunStart(this, runnerInstance.getRunnerDataObjet())
     this.eventPublisher.publishEvent(startEvent)
     val runId = startEvent.response ?: throw IllegalStateException("Run Service did not respond")
     runnerInstance.setLastRunId(runId)
     runnerRepository.save(runnerInstance.getRunnerDataObjet())
-    return runId
+    return CreatedRun(id = runId)
   }
 
   fun stopLastRunOf(runnerInstance: RunnerInstance) {

--- a/runner/src/main/openapi/runner.yaml
+++ b/runner/src/main/openapi/runner.yaml
@@ -206,12 +206,11 @@ paths:
       summary: Start a run with runner parameters
       responses:
         "202":
-          description: the Run id started
+          description: the newly created Run info
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                example: r-p75189n1m43k
+                $ref: "#/components/schemas/CreatedRun"
         "404":
           description: the Runner specified is unknown or you don't have access to it
 
@@ -771,6 +770,15 @@ components:
         - Rejected
         - Unknown
         - Validated
+    CreatedRun:
+      type: object
+      description: Newle created Run info
+      properties:
+        id:
+          type: string
+          description: Run id
+      required:
+        - id
   examples:
     BreweryRunnerIn:
       summary: Brewery Runner input example


### PR DESCRIPTION
Ideally we should return a RunInstance but this data obejct is defined in the run openapi, not accessible from the runner one. But having a proper object should ease extension if we need to add more data.