### PR TITLE
[PROD-13734] Fix update solution with no runTemplates cause runTemplates reset to empty list

### DIFF
--- a/solution/src/integrationTest/kotlin/com/cosmotech/solution/service/SolutionServiceIntegrationTest.kt
+++ b/solution/src/integrationTest/kotlin/com/cosmotech/solution/service/SolutionServiceIntegrationTest.kt
@@ -415,6 +415,60 @@ class SolutionServiceIntegrationTest : CsmRedisTestBase() {
   }
 
   @Test
+  fun `test update solution with runTemplates specified`() {
+
+    val baseSolutionRunTemplates =
+        mutableListOf(
+            RunTemplate(
+                id = "runtemplate1",
+                name = "rt_name1",
+                run = true,
+                parameterGroups = mutableListOf("p_1", "p_2")))
+
+    val modifiedSolutionRunTemplates =
+        mutableListOf(
+            RunTemplate(
+                id = "new_runtemplate1",
+                name = "new_rt_name1",
+                run = false,
+                parameterGroups = mutableListOf("new_p_1", "new_p_2")))
+
+    val baseSolution = makeSolution(organizationSaved.id!!, baseSolutionRunTemplates)
+    val baseSolutionSaved = solutionApiService.createSolution(organizationSaved.id!!, baseSolution)
+
+    val updateSolutionSaved =
+        solutionApiService.updateSolution(
+            organizationSaved.id!!,
+            baseSolutionSaved.id!!,
+            baseSolutionSaved.apply { runTemplates = modifiedSolutionRunTemplates })
+
+    assertEquals(baseSolutionRunTemplates, updateSolutionSaved.runTemplates)
+  }
+
+  @Test
+  fun `test update solution with empty runTemplates specified`() {
+
+    val baseSolutionRunTemplates =
+        mutableListOf(
+            RunTemplate(
+                id = "runtemplate1",
+                name = "rt_name1",
+                run = true,
+                parameterGroups = mutableListOf("p_1", "p_2")))
+
+    val baseSolution = makeSolution(organizationSaved.id!!, baseSolutionRunTemplates)
+    val baseSolutionSaved = solutionApiService.createSolution(organizationSaved.id!!, baseSolution)
+
+    val updateSolutionSaved =
+        solutionApiService.updateSolution(
+            organizationSaved.id!!,
+            baseSolutionSaved.id!!,
+            baseSolutionSaved.apply { runTemplates = mutableListOf() })
+
+    assertEquals(baseSolutionRunTemplates, updateSolutionSaved.runTemplates)
+  }
+
+  @Test
   fun `test get security endpoint`() {
     // should return the current security
     val solutionSecurity =

--- a/solution/src/main/kotlin/com/cosmotech/solution/service/SolutionServiceImpl.kt
+++ b/solution/src/main/kotlin/com/cosmotech/solution/service/SolutionServiceImpl.kt
@@ -243,7 +243,8 @@ class SolutionServiceImpl(
     // solutionId update is allowed but must be done with care. Maybe limit to minor update?
     var hasChanged =
         existingSolution
-            .compareToAndMutateIfNeeded(solution, excludedFields = arrayOf("ownerId"))
+            .compareToAndMutateIfNeeded(
+                solution, excludedFields = arrayOf("ownerId", "runTemplates"))
             .isNotEmpty()
 
     if (solution.ownerId != null && solution.changed(existingSolution) { ownerId }) {


### PR DESCRIPTION
### Context

- `runTemplates` property definition on Solution has changed previously:
  - `runTemplates` is now required
  - default value is `[]`
- `updateSolution` does not exclude `runTemplates` field resulting an update with the `runTemplates` default value (a.k.a `[]`). the value was reset

### Fix
To resolve this, `runTemplates` property is ignored on `updateSolution` call. RunTemplate associated to a Solution should be updated through `updateSolutionRunTemplate`.