### PR TITLE
Mount output and temp directory in argo containers

### DIFF
--- a/run/src/main/kotlin/com/cosmotech/run/RunContainerFactory.kt
+++ b/run/src/main/kotlin/com/cosmotech/run/RunContainerFactory.kt
@@ -44,6 +44,10 @@ private const val DATASET_PATH_VAR = "CSM_DATASET_ABSOLUTE_PATH"
 private const val DATASET_PATH = "/mnt/scenariorun-data"
 private const val PARAMETERS_PATH_VAR = "CSM_PARAMETERS_ABSOLUTE_PATH"
 private const val PARAMETERS_PATH = "/mnt/scenariorun-parameters"
+private const val OUTPUT_PATH_VAR = "CSM_OUTPUT_ABSOLUTE_PATH"
+private const val OUTPUT_PATH = "/pkg/share/Simulation/Output"
+private const val TEMP_PATH_VAR = "CSM_TEMP_ABSOLUTE_PATH"
+private const val TEMP_PATH = "/usr/tmp"
 private const val PARAMETERS_ORGANIZATION_VAR = "CSM_ORGANIZATION_ID"
 private const val PARAMETERS_WORKSPACE_VAR = "CSM_WORKSPACE_ID"
 private const val PARAMETERS_RUNNER_VAR = "CSM_RUNNER_ID"
@@ -365,6 +369,8 @@ internal fun getMinimalCommonEnvVars(
           API_BASE_SCOPE_VAR to containerScopes,
           DATASET_PATH_VAR to DATASET_PATH,
           PARAMETERS_PATH_VAR to PARAMETERS_PATH,
+          OUTPUT_PATH_VAR to OUTPUT_PATH,
+          TEMP_PATH_VAR to TEMP_PATH,
       )
   return (commonEnvVars + twinCacheEnvVars).toMutableMap()
 }

--- a/run/src/main/kotlin/com/cosmotech/run/workflow/argo/WorkflowBuilders.kt
+++ b/run/src/main/kotlin/com/cosmotech/run/workflow/argo/WorkflowBuilders.kt
@@ -37,8 +37,12 @@ private const val CSM_DEFAULT_WORKFLOW_NAME = "default-workflow-"
 internal const val VOLUME_CLAIM = "datadir"
 internal const val VOLUME_CLAIM_DATASETS_SUBPATH = "datasetsdir"
 internal const val VOLUME_CLAIM_PARAMETERS_SUBPATH = "parametersdir"
+internal const val VOLUME_CLAIM_OUTPUT_SUBPATH = "outputdir"
+internal const val VOLUME_CLAIM_TEMP_SUBPATH = "tempdir"
 private const val VOLUME_DATASETS_PATH = "/mnt/scenariorun-data"
 private const val VOLUME_PARAMETERS_PATH = "/mnt/scenariorun-parameters"
+private const val VOLUME_OUTPUT_PATH = "/pkg/share/Simulation/Output"
+private const val VOLUME_TEMP_PATH = "/usr/tmp"
 internal const val CSM_ARGO_WORKFLOWS_TIMEOUT = 28800
 internal const val ALWAYS_PULL_POLICY = "Always"
 
@@ -66,7 +70,15 @@ internal fun buildTemplate(
           V1VolumeMount()
               .name(VOLUME_CLAIM)
               .mountPath(VOLUME_PARAMETERS_PATH)
-              .subPath(VOLUME_CLAIM_PARAMETERS_SUBPATH))
+              .subPath(VOLUME_CLAIM_PARAMETERS_SUBPATH),
+          V1VolumeMount()
+              .name(VOLUME_CLAIM)
+              .mountPath(VOLUME_OUTPUT_PATH)
+              .subPath(VOLUME_CLAIM_OUTPUT_SUBPATH),
+          V1VolumeMount()
+              .name(VOLUME_CLAIM)
+              .mountPath(VOLUME_TEMP_PATH)
+              .subPath(VOLUME_CLAIM_TEMP_SUBPATH))
 
   val sizingInfo = runContainer.runSizing ?: BASIC_SIZING.toContainerResourceSizing()
 

--- a/run/src/test/kotlin/com/cosmotech/run/ContainerFactoryTests.kt
+++ b/run/src/test/kotlin/com/cosmotech/run/ContainerFactoryTests.kt
@@ -178,6 +178,8 @@ class ContainerFactoryTests {
                 "CSM_API_URL" to csmPlatformProperties.api.baseUrl,
                 "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",
                 "CSM_PARAMETERS_ABSOLUTE_PATH" to "/mnt/scenariorun-parameters",
+                "CSM_OUTPUT_ABSOLUTE_PATH" to "/pkg/share/Simulation/Output",
+                "CSM_TEMP_ABSOLUTE_PATH" to "/usr/tmp",
                 "TWIN_CACHE_HOST" to csmPlatformProperties.twincache.host,
                 "TWIN_CACHE_PORT" to csmPlatformProperties.twincache.port,
                 "TWIN_CACHE_PASSWORD" to csmPlatformProperties.twincache.password,

--- a/run/src/test/kotlin/com/cosmotech/run/workflow/argo/WorkflowBuildersTests.kt
+++ b/run/src/test/kotlin/com/cosmotech/run/workflow/argo/WorkflowBuildersTests.kt
@@ -468,7 +468,15 @@ class WorkflowBuildersTests {
             V1VolumeMount()
                 .name(VOLUME_CLAIM)
                 .mountPath("/mnt/scenariorun-parameters")
-                .subPath(VOLUME_CLAIM_PARAMETERS_SUBPATH))
+                .subPath(VOLUME_CLAIM_PARAMETERS_SUBPATH),
+            V1VolumeMount()
+                .name(VOLUME_CLAIM)
+                .mountPath("/pkg/share/Simulation/Output")
+                .subPath(VOLUME_CLAIM_OUTPUT_SUBPATH),
+            V1VolumeMount()
+                .name(VOLUME_CLAIM)
+                .mountPath("/usr/tmp")
+                .subPath(VOLUME_CLAIM_TEMP_SUBPATH))
     assertEquals(expected, template.container?.volumeMounts)
   }
 


### PR DESCRIPTION
Mount output and temp directory in argo containers to be compatible with k8s secured option securityContext.readOnlyRootFilesystem=true