### PR TITLE
[PROD-13928] Make Runner.datasetList optional again

### DIFF
--- a/doc/Models/Runner.md
+++ b/doc/Models/Runner.md
@@ -19,7 +19,7 @@
 | **ownerName** | **String** | the name of the owner | [optional] [default to null] |
 | **solutionName** | **String** | the Solution name | [optional] [default to null] |
 | **runTemplateName** | **String** | the Solution Run Template name associated with this Runner | [optional] [default to null] |
-| **datasetList** | **List** | the list of Dataset Id associated to this Runner Run Template | [default to []] |
+| **datasetList** | **List** | the list of Dataset Id associated to this Runner Run Template | [optional] [default to null] |
 | **runSizing** | [**RunnerResourceSizing**](RunnerResourceSizing.md) |  | [optional] [default to null] |
 | **parametersValues** | [**List**](RunnerRunTemplateParameterValue.md) | the list of Solution Run Template parameters values | [optional] [default to null] |
 | **lastRunId** | **String** | last run id from current runner | [optional] [default to null] |

--- a/openapi/plantuml/schemas.plantuml
+++ b/openapi/plantuml/schemas.plantuml
@@ -376,7 +376,7 @@ entity Runner {
     ownerName: String
     solutionName: String
     runTemplateName: String
-    * datasetList: List<String>
+    datasetList: List<String>
     runSizing: RunnerResourceSizing
     parametersValues: List<RunnerRunTemplateParameterValue>
     lastRunId: String

--- a/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceIntegrationTest.kt
+++ b/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceIntegrationTest.kt
@@ -414,7 +414,7 @@ class RunnerServiceIntegrationTest : CsmRedisTestBase() {
 
     logger.info(
         "should add an Access Control and assert it is the one created in the linked datasets")
-    runnerSaved.datasetList.forEach {
+    runnerSaved.datasetList!!.forEach {
       assertDoesNotThrow {
         datasetApiService.getDatasetAccessControl(organizationSaved.id!!, it, TEST_USER_MAIL)
       }
@@ -432,7 +432,7 @@ class RunnerServiceIntegrationTest : CsmRedisTestBase() {
 
     logger.info(
         "should update the Access Control and assert it has been updated in the linked datasets")
-    runnerSaved.datasetList.forEach {
+    runnerSaved.datasetList!!.forEach {
       assertEquals(
           ROLE_EDITOR,
           datasetApiService
@@ -457,7 +457,7 @@ class RunnerServiceIntegrationTest : CsmRedisTestBase() {
 
     logger.info(
         "should remove the Access Control and assert it has been removed in the linked datasets")
-    runnerSaved.datasetList.forEach {
+    runnerSaved.datasetList!!.forEach {
       assertThrows<CsmResourceNotFoundException> {
         datasetApiService.getDatasetAccessControl(organizationSaved.id!!, it, TEST_USER_MAIL)
       }
@@ -531,7 +531,7 @@ class RunnerServiceIntegrationTest : CsmRedisTestBase() {
   fun `test on runner delete keep datasets`() {
     runnerApiService.deleteRunner(organizationSaved.id!!, workspaceSaved.id!!, runnerSaved.id!!)
 
-    runnerSaved.datasetList.forEach { dataset ->
+    runnerSaved.datasetList!!.forEach { dataset ->
       assertDoesNotThrow { datasetApiService.findDatasetById(organizationSaved.id!!, dataset) }
     }
   }
@@ -657,7 +657,7 @@ class RunnerServiceIntegrationTest : CsmRedisTestBase() {
     runnerSaved = runnerApiService.createRunner(organizationSaved.id!!, workspaceSaved.id!!, runner)
 
     datasetSaved =
-        datasetApiService.findDatasetById(organizationSaved.id!!, runnerSaved.datasetList[0])
+        datasetApiService.findDatasetById(organizationSaved.id!!, runnerSaved.datasetList!![0])
     runnerApiService.deleteRunner(organizationSaved.id!!, workspaceSaved.id!!, runnerSaved.id!!)
 
     assertDoesNotThrow {
@@ -679,7 +679,7 @@ class RunnerServiceIntegrationTest : CsmRedisTestBase() {
     runnerSaved = runnerApiService.createRunner(organizationSaved.id!!, workspaceSaved.id!!, runner)
 
     datasetSaved =
-        datasetApiService.findDatasetById(organizationSaved.id!!, runnerSaved.datasetList[0])
+        datasetApiService.findDatasetById(organizationSaved.id!!, runnerSaved.datasetList!![0])
     runnerApiService.addRunnerAccessControl(
         organizationSaved.id!!,
         workspaceSaved.id!!,

--- a/runner/src/main/kotlin/com/cosmotech/runner/service/RunnerService.kt
+++ b/runner/src/main/kotlin/com/cosmotech/runner/service/RunnerService.kt
@@ -42,6 +42,7 @@ import com.cosmotech.workspace.WorkspaceApiServiceInterface
 import com.cosmotech.workspace.domain.Workspace
 import com.cosmotech.workspace.service.getRbac
 import java.time.Instant
+import kotlin.collections.mutableListOf
 import org.springframework.context.annotation.Scope
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
@@ -179,6 +180,7 @@ class RunnerService(
               ownerId = getCurrentAuthenticatedUserName(csmPlatformProperties),
               organizationId = organization!!.id,
               workspaceId = workspace!!.id,
+              datasetList = mutableListOf(),
               creationDate = now,
               lastUpdate = now)
     }
@@ -207,8 +209,8 @@ class RunnerService(
 
       // take newly added datasets and propagate existing ACL on it
       this.runner.datasetList
-          .filterNot { beforeMutateDatasetList.contains(it) }
-          .forEach { newDatasetId ->
+          ?.filterNot { beforeMutateDatasetList?.contains(it) ?: false }
+          ?.forEach { newDatasetId ->
             this.runner.security?.accessControlList?.forEach {
               this.propagateAccessControlToDataset(newDatasetId, it.id, it.role)
             }
@@ -363,7 +365,7 @@ class RunnerService(
     }
 
     private fun propagateAccessControlToDatasets(userId: String, role: String) {
-      this.runner.datasetList.forEach { datasetId ->
+      this.runner.datasetList?.forEach { datasetId ->
         propagateAccessControlToDataset(datasetId, userId, role)
       }
     }
@@ -384,7 +386,7 @@ class RunnerService(
 
     private fun removeAccessControlToDatasets(userId: String) {
       val organizationId = this.runner.organizationId!!
-      this.runner.datasetList.forEach { datasetId ->
+      this.runner.datasetList?.forEach { datasetId ->
         val datasetACL =
             datasetApiService.findDatasetById(organizationId, datasetId).getRbac().accessControlList
 

--- a/runner/src/main/openapi/runner.yaml
+++ b/runner/src/main/openapi/runner.yaml
@@ -653,7 +653,6 @@ components:
         datasetList:
           type: array
           description: the list of Dataset Id associated to this Runner Run Template
-          default: []
           items:
             type: string
         runSizing:
@@ -675,8 +674,6 @@ components:
           x-field-extra-annotation: "@com.redis.om.spring.annotations.Indexed"
           allOf:
             - $ref: '#/components/schemas/RunnerSecurity'
-      required:
-        - datasetList
     RunnerSecurity:
       type: object
       description: the Runner security information


### PR DESCRIPTION
Requiring it breaks the updateRunner endpoint, or at minima forces users to provide that field (with current values) even if that's not the field they want to modify.
This should be fixed in a better way when we find the time to rework the API contract and split the data model for creation, update and reading.