### PR TITLE
Upgrade argo-client-java from v3.4.3 to v3.5.11

### DIFF
--- a/run/build.gradle.kts
+++ b/run/build.gradle.kts
@@ -6,7 +6,7 @@ import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 plugins { id("org.jetbrains.kotlinx.kover") }
 
 dependencies {
-  implementation("io.argoproj.workflow:argo-client-java:v3.4.3")
+  implementation("io.argoproj.workflow:argo-client-java:v3.5.11")
   implementation("com.squareup.retrofit2:retrofit:2.9.0")
   implementation("com.squareup.retrofit2:converter-scalars:2.9.0")
 

--- a/run/src/main/kotlin/com/cosmotech/run/metrics/RunMetrics.kt
+++ b/run/src/main/kotlin/com/cosmotech/run/metrics/RunMetrics.kt
@@ -92,10 +92,7 @@ internal class RunMetrics(
 
   private fun getRunningWorkflowsCount(): Map<WorkflowContextData?, Int> {
     val runWorkflows =
-        this.workflowService.findWorkflowStatusByLabel(
-            "$WORKFLOW_TYPE_LABEL=$WORKFLOW_TYPE_RUN",
-            true,
-        )
+        this.workflowService.findWorkflowStatusByLabel("$WORKFLOW_TYPE_LABEL=$WORKFLOW_TYPE_RUN")
     return runWorkflows
         .filter { it.status == RUNNING_STATUS }
         .groupingBy { it.contextData }

--- a/run/src/main/kotlin/com/cosmotech/run/service/RunServiceImpl.kt
+++ b/run/src/main/kotlin/com/cosmotech/run/service/RunServiceImpl.kt
@@ -160,7 +160,7 @@ class RunServiceImpl(
     val defaultPageSize = csmPlatformProperties.twincache.run.defaultPageSize
     var pageRequest: Pageable = PageRequest.ofSize(defaultPageSize)
 
-    var runs = mutableListOf<Run>()
+    val runs = mutableListOf<Run>()
 
     do {
       val pagedRuns =
@@ -450,6 +450,8 @@ class RunServiceImpl(
 
   private fun deleteRun(run: Run) {
     try {
+
+      workflowService.stopWorkflow(run)
 
       if (csmPlatformProperties.internalResultServices?.enabled == true)
           adminRunStorageTemplate.dropDB(run.id!!)

--- a/run/src/main/kotlin/com/cosmotech/run/workflow/WorkflowService.kt
+++ b/run/src/main/kotlin/com/cosmotech/run/workflow/WorkflowService.kt
@@ -36,13 +36,9 @@ interface WorkflowService : HealthIndicator {
   /**
    * Find WorkflowStatus by label
    * @param labelSelector a label used to filter workflow
-   * @param skipArchive Do not search workflows in archive
    * @return a list of all WorkflowStatus corresponding to the labelSelector
    */
-  fun findWorkflowStatusByLabel(
-      labelSelector: String,
-      skipArchive: Boolean = false
-  ): List<WorkflowStatus>
+  fun findWorkflowStatusByLabel(labelSelector: String): List<WorkflowStatus>
 
   /**
    * Get a Run status


### PR DESCRIPTION
   Since Argo Workflows 3.5, listing workflows will also list archived ones.
   See [here](https://argo-workflows.readthedocs.io/en/latest/upgrading/#upgrading-to-v35)
   and [here](https://github.com/argoproj/argo-workflows/issues/10781)
   and [here](https://github.com/argoproj/argo-workflows/blob/release-3.5/ui/src/models/workflows.ts#L542-L560)
   The only way I found to filter archived ones from this list is to filter by following label
   If this label is in the workflow's labels => the workflow is archived
   If not, the workflow is not archived