### PR TITLE
Only pass the PVC storage class if we have one

### DIFF
--- a/api/kubernetes/helm-chart/templates/pvc.yaml
+++ b/api/kubernetes/helm-chart/templates/pvc.yaml
@@ -15,5 +15,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
   storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
 {{end}}


### PR DESCRIPTION
This should avoid issues on subsequent chart deployment where the default storage class has been resolved and conflicts with a 'nil' or empty default value