### PR TITLE
[PROD-9005] Make sure the parameter's varType are the one from the solution

### DIFF
--- a/runner/src/main/kotlin/com/cosmotech/runner/service/RunnerService.kt
+++ b/runner/src/main/kotlin/com/cosmotech/runner/service/RunnerService.kt
@@ -241,6 +241,7 @@ class RunnerService(
               "creationDate",
               "security")
       this.runner.compareToAndMutateIfNeeded(runner, excludedFields = excludeFields)
+      consolidateParametersVarType()
 
       // take newly added datasets and propagate existing ACL on it
       this.runner.datasetList
@@ -288,6 +289,7 @@ class RunnerService(
         val parameterValueList = this.runner.parametersValues ?: mutableListOf()
         parameterValueList.addAll(inheritedParameterValues)
         this.runner.parametersValues = parameterValueList
+        consolidateParametersVarType()
 
         // Compute rootId
         this.runner.parentId?.let {
@@ -298,6 +300,22 @@ class RunnerService(
                   .rootId
                   ?: this.runner.parentId
         }
+      }
+    }
+
+    fun consolidateParametersVarType() {
+      val solutionParameters =
+          workspace
+              ?.solution
+              ?.solutionId
+              ?.let { solutionApiService.findSolutionById(organization?.id!!, it) }
+              ?.parameters
+
+      this.runner.parametersValues?.forEach { runnerParam ->
+        solutionParameters
+            ?.find { it.id == runnerParam.parameterId }
+            ?.varType
+            ?.let { runnerParam.varType = it }
       }
     }
 


### PR DESCRIPTION
Target fix is to rework the api to remove varType from the input data instead of relying on the buggy readOnly config.
In the mean time, consolidate every varType with the reference value from the solution.