### PR TITLE
Jrey/backport 9005

### DIFF
--- a/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceIntegrationTest.kt
+++ b/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceIntegrationTest.kt
@@ -219,6 +219,72 @@ class RunnerServiceIntegrationTest : CsmRedisTestBase() {
   }
 
   @Test
+  fun `test createRunner and check parameterValues data`() {
+
+    logger.info(
+        "should create a new Runner and retrieve parameter varType from solution ignoring the one declared")
+    val newRunner =
+        makeRunner(
+            organizationSaved.id!!,
+            workspaceSaved.id!!,
+            solutionSaved.id!!,
+            "NewRunner",
+            mutableListOf(datasetSaved.id!!),
+            parametersValues =
+                mutableListOf(
+                    RunnerRunTemplateParameterValue(
+                        parameterId = "param1", value = "7", varType = "ignored_var_type")))
+    val newRunnerSaved =
+        runnerApiService.createRunner(organizationSaved.id!!, workspaceSaved.id!!, newRunner)
+
+    assertNotNull(newRunnerSaved.parametersValues)
+    assertTrue(newRunnerSaved.parametersValues!!.size == 1)
+    assertEquals("param1", newRunnerSaved.parametersValues!![0].parameterId)
+    assertEquals("7", newRunnerSaved.parametersValues!![0].value)
+    assertEquals("integer", newRunnerSaved.parametersValues!![0].varType)
+  }
+
+  @Test
+  fun `test updateRunner and check parameterValues data`() {
+
+    logger.info(
+        "should create a new Runner and retrieve parameter varType from solution ignoring the one declared")
+    val creationParameterValue =
+        RunnerRunTemplateParameterValue(
+            parameterId = "param1", value = "7", varType = "ignored_var_type")
+    val newRunner =
+        makeRunner(
+            organizationSaved.id!!,
+            workspaceSaved.id!!,
+            solutionSaved.id!!,
+            "NewRunner",
+            mutableListOf(datasetSaved.id!!),
+            parametersValues = mutableListOf(creationParameterValue))
+    val newRunnerSaved =
+        runnerApiService.createRunner(organizationSaved.id!!, workspaceSaved.id!!, newRunner)
+
+    assertNotNull(newRunnerSaved.parametersValues)
+    assertTrue(newRunnerSaved.parametersValues!!.size == 1)
+    assertEquals(creationParameterValue, newRunnerSaved.parametersValues!![0])
+
+    val newParameterValue =
+        RunnerRunTemplateParameterValue(
+            parameterId = "param1", value = "10", varType = "still_ignored_var_type")
+    val updateRunnerSaved =
+        runnerApiService.updateRunner(
+            organizationSaved.id!!,
+            workspaceSaved.id!!,
+            newRunnerSaved.id!!,
+            newRunnerSaved.apply { parametersValues = mutableListOf(newParameterValue) })
+
+    assertNotNull(updateRunnerSaved.parametersValues)
+    assertTrue(updateRunnerSaved.parametersValues!!.size == 1)
+    assertEquals("param1", updateRunnerSaved.parametersValues!![0].parameterId)
+    assertEquals("10", updateRunnerSaved.parametersValues!![0].value)
+    assertEquals("integer", updateRunnerSaved.parametersValues!![0].varType)
+  }
+
+  @Test
   fun `test CRUD operations on Runner as Platform Admin`() {
     every { getCurrentAccountIdentifier(any()) } returns "random_user_with_patform_admin_role"
     every { getCurrentAuthenticatedRoles(any()) } returns listOf(ROLE_PLATFORM_ADMIN)
@@ -844,6 +910,16 @@ class RunnerServiceIntegrationTest : CsmRedisTestBase() {
             mutableListOf(
                 RunTemplateParameterGroup(
                     id = "testParameterGroups", parameters = mutableListOf("param1", "param2"))),
+        parameters =
+            mutableListOf(
+                RunTemplateParameter(
+                    id = "param1",
+                    maxValue = "10",
+                    minValue = "0",
+                    defaultValue = "5",
+                    varType = "integer"),
+                RunTemplateParameter(id = "param2", varType = "%DATASET%"),
+            ),
         runTemplates =
             mutableListOf(
                 RunTemplate(

--- a/runner/src/main/kotlin/com/cosmotech/runner/service/RunnerService.kt
+++ b/runner/src/main/kotlin/com/cosmotech/runner/service/RunnerService.kt
@@ -241,21 +241,21 @@ class RunnerService(
       }
     }
 
-      fun consolidateParametersVarType() {
-          val solutionParameters =
-              workspace
-                  ?.solution
-                  ?.solutionId
-                  ?.let { solutionApiService.findSolutionById(organization?.id!!, it) }
-                  ?.parameters
+    fun consolidateParametersVarType() {
+      val solutionParameters =
+          workspace
+              ?.solution
+              ?.solutionId
+              ?.let { solutionApiService.findSolutionById(organization?.id!!, it) }
+              ?.parameters
 
-          this.runner.parametersValues?.forEach { runnerParam ->
-              solutionParameters
-                  ?.find { it.id == runnerParam.parameterId }
-                  ?.varType
-                  ?.let { runnerParam.varType = it }
-          }
+      this.runner.parametersValues?.forEach { runnerParam ->
+        solutionParameters
+            ?.find { it.id == runnerParam.parameterId }
+            ?.varType
+            ?.let { runnerParam.varType = it }
       }
+    }
 
     fun setAccessControl(runnerAccessControl: RunnerAccessControl) {
       // create a rbacSecurity object from runner Rbac by adding user with id and role in

--- a/scenario/src/integrationTest/kotlin/com/cosmotech/scenario/service/ScenarioServiceIntegrationTest.kt
+++ b/scenario/src/integrationTest/kotlin/com/cosmotech/scenario/service/ScenarioServiceIntegrationTest.kt
@@ -301,7 +301,9 @@ class ScenarioServiceIntegrationTest : CsmRedisTestBase() {
             parametersValues =
                 mutableListOf(
                     ScenarioRunTemplateParameterValue(
-                        parameterId = "param1",
+                        parameterId = "param1", value = "105", varType = "exclude_read_only_value"),
+                    ScenarioRunTemplateParameterValue(
+                        parameterId = "not_defined_parameter",
                         value = "105",
                         varType = "exclude_read_only_value")))
 
@@ -317,6 +319,104 @@ class ScenarioServiceIntegrationTest : CsmRedisTestBase() {
     assertEquals("param2", scenarioWithParametersSaved.parametersValues!![1].parameterId)
     assertEquals("param2VarType", scenarioWithParametersSaved.parametersValues!![1].varType)
     assertEquals("", scenarioWithParametersSaved.parametersValues!![1].value)
+  }
+
+  @Test
+  fun `test updateScenario with empty parameters`() {
+    every { getCurrentAuthenticatedRoles(any()) } returns listOf("Platform.Admin")
+
+    val scenarioWithoutParameters =
+        makeScenario(
+            organizationSaved.id!!,
+            workspaceSaved.id!!,
+            solutionSaved.id!!,
+            "ScenarioWithoutParameters",
+            mutableListOf(datasetSaved.id!!))
+
+    val scenarioWithoutParametersSaved =
+        scenarioApiService.createScenario(
+            organizationSaved.id!!, workspaceSaved.id!!, scenarioWithoutParameters)
+
+    val updatedScenarioWithoutParametersSaved =
+        scenarioApiService.updateScenario(
+            organizationSaved.id!!,
+            workspaceSaved.id!!,
+            scenarioWithoutParametersSaved.id!!,
+            scenarioWithoutParametersSaved.apply {
+              parametersValues =
+                  mutableListOf(
+                      ScenarioRunTemplateParameterValue(
+                          parameterId = "param1",
+                          value = "107",
+                          varType = "exclude_read_only_value"),
+                      ScenarioRunTemplateParameterValue(
+                          parameterId = "not_defined_parameter",
+                          value = "105",
+                          varType = "exclude_read_only_value"))
+            })
+
+    assertNotNull(updatedScenarioWithoutParametersSaved.parametersValues)
+    assertTrue(updatedScenarioWithoutParametersSaved.parametersValues!!.size == 2)
+    assertEquals("param1", updatedScenarioWithoutParametersSaved.parametersValues!![0].parameterId)
+    assertEquals(
+        "param1VarType", updatedScenarioWithoutParametersSaved.parametersValues!![0].varType)
+    assertEquals("107", updatedScenarioWithoutParametersSaved.parametersValues!![0].value)
+    assertEquals("param2", updatedScenarioWithoutParametersSaved.parametersValues!![1].parameterId)
+    assertEquals(
+        "param2VarType", updatedScenarioWithoutParametersSaved.parametersValues!![1].varType)
+    assertEquals("", updatedScenarioWithoutParametersSaved.parametersValues!![1].value)
+  }
+
+  @Test
+  fun `test updateScenario with non-empty parameters`() {
+    every { getCurrentAuthenticatedRoles(any()) } returns listOf("Platform.Admin")
+
+    val scenarioWithParameters =
+        makeScenario(
+            organizationSaved.id!!,
+            workspaceSaved.id!!,
+            solutionSaved.id!!,
+            "ScenarioWithParameters",
+            mutableListOf(datasetSaved.id!!),
+            parametersValues =
+                mutableListOf(
+                    ScenarioRunTemplateParameterValue(
+                        parameterId = "param1", value = "100", varType = "exclude_read_only_value"),
+                    ScenarioRunTemplateParameterValue(
+                        parameterId = "param2",
+                        value = "this_is_a_value",
+                        varType = "exclude_read_only_value")))
+
+    val scenarioWithParametersSaved =
+        scenarioApiService.createScenario(
+            organizationSaved.id!!, workspaceSaved.id!!, scenarioWithParameters)
+
+    val updatedScenarioWithParametersSaved =
+        scenarioApiService.updateScenario(
+            organizationSaved.id!!,
+            workspaceSaved.id!!,
+            scenarioWithParametersSaved.id!!,
+            scenarioWithParametersSaved.apply {
+              parametersValues =
+                  mutableListOf(
+                      ScenarioRunTemplateParameterValue(
+                          parameterId = "param1",
+                          value = "107",
+                          varType = "exclude_read_only_value"),
+                      ScenarioRunTemplateParameterValue(
+                          parameterId = "not_defined_parameter",
+                          value = "105",
+                          varType = "exclude_read_only_value"))
+            })
+
+    assertNotNull(updatedScenarioWithParametersSaved.parametersValues)
+    assertTrue(updatedScenarioWithParametersSaved.parametersValues!!.size == 2)
+    assertEquals("param1", updatedScenarioWithParametersSaved.parametersValues!![0].parameterId)
+    assertEquals("param1VarType", updatedScenarioWithParametersSaved.parametersValues!![0].varType)
+    assertEquals("107", updatedScenarioWithParametersSaved.parametersValues!![0].value)
+    assertEquals("param2", updatedScenarioWithParametersSaved.parametersValues!![1].parameterId)
+    assertEquals("param2VarType", updatedScenarioWithParametersSaved.parametersValues!![1].varType)
+    assertEquals("", updatedScenarioWithParametersSaved.parametersValues!![1].value)
   }
 
   @Test
@@ -446,9 +546,6 @@ class ScenarioServiceIntegrationTest : CsmRedisTestBase() {
   @Test
   fun `test Scenario Parameter Values as User Admin`() {
     every { getCurrentAuthenticatedRoles(any()) } returns listOf("Platform.Admin")
-
-    logger.info("should assert that the Scenario has no Parameter Values")
-    assertTrue(scenarioSaved.parametersValues!!.isEmpty())
 
     logger.info("should add a Parameter Value and assert it has been added")
     val params =


### PR DESCRIPTION

Target fix is to rework the api to remove varType from the input data instead of relying on the buggy readOnly config.
In the mean time, consolidate every varType with the reference value from the solution.

See: https://github.com/Cosmo-Tech/cosmotech-api/pull/820