### PR TITLE
fix: Do not trust and send traffic through CORS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,5 +379,5 @@ kube-linter --config api/kubernetes/.kube-linter.yaml lint api/kubernetes/csm-ar
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ### License dependencies
-The product is using the following dependencies, under their respective licenses: [License check page](https://htmlpreview.github.io/?https://github.com/Cosmo-Tech/cosmotech-api/blob/main/doc/licenses/index.html)
+The product is using the following dependencies, under their respective licenses: [License check page](https://github.com/Cosmo-Tech/cosmotech-api/blob/main/doc/licenses/index.html)
 


### PR DESCRIPTION
To have a nice list of the licenses we were sending users through the codetabs CORS proxy (https://codetabs.com/).