### PR TITLE
fix: repair generated python client code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,12 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 // implementations/configurations in a 'buildSrc' included build.
 // See https://docs.gradle.org/current/userguide/organizing_gradle_projects.html#sec:build_sources
 
+buildscript {
+    configurations.all {
+        resolutionStrategy.force("com.samskivert:jmustache:1.15")
+    }
+}
+
 plugins {
   val kotlinVersion = "1.9.23"
   kotlin("jvm") version kotlinVersion

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,9 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 
 buildscript {
     configurations.all {
+      // Due to bug OpenAPITools/openapi-generator#20375 when we use another
+      // plugin that also depends on jmustache the newer version ends up being
+      // used and it breaks the generation of the python client.
         resolutionStrategy.force("com.samskivert:jmustache:1.15")
     }
 }


### PR DESCRIPTION
The openapi-generator-gradle-plugin depends has a transitive dependency on com.samskivert:jmustache:1.15, however the .owasp.dependencycheck.gradle.plugin depends on the more recent 1.16 version so when
both plugins are included the generated python code has syntax errors (see bug issue: https://github.com/OpenAPITools/openapi-generator/issues/20375) To avoid this conflict of plugin dependencies we have to force the resolution of dependencies to
keep the old version. Forcing the dependency also introduces some changes in the typescript client, but fortunately these are new lines that do not seem to have an effect