### PR TITLE
Change query behind findAllDatasets when you're a Platform.Admin

### DIFF
--- a/dataset/src/main/kotlin/com/cosmotech/dataset/repository/DatasetRepository.kt
+++ b/dataset/src/main/kotlin/com/cosmotech/dataset/repository/DatasetRepository.kt
@@ -27,8 +27,8 @@ interface DatasetRepository : RedisDocumentRepository<Dataset, String> {
       pageRequest: PageRequest
   ): Page<Dataset>
 
-  @Query("(@organizationId:{\$organizationId})")
-  fun findByOrganizationIdNoSecurity(
+  @Query("@organizationId:{\$organizationId}")
+  fun findByOrganizationId(
       @Sanitize @Param("organizationId") organizationId: String,
       pageRequest: PageRequest
   ): Page<Dataset>

--- a/dataset/src/main/kotlin/com/cosmotech/dataset/service/DatasetServiceImpl.kt
+++ b/dataset/src/main/kotlin/com/cosmotech/dataset/service/DatasetServiceImpl.kt
@@ -155,7 +155,7 @@ class DatasetServiceImpl(
               val currentUser = getCurrentAccountIdentifier(this.csmPlatformProperties)
               datasetRepository.findByOrganizationId(organizationId, currentUser, it).toList()
             } else {
-              datasetRepository.findByOrganizationIdNoSecurity(organizationId, it).toList()
+              datasetRepository.findByOrganizationId(organizationId, it).toList()
             }
           }
     } else {
@@ -164,7 +164,7 @@ class DatasetServiceImpl(
             val currentUser = getCurrentAccountIdentifier(this.csmPlatformProperties)
             datasetRepository.findByOrganizationId(organizationId, currentUser, pageable).toList()
           } else {
-            datasetRepository.findByOrganizationIdNoSecurity(organizationId, pageable).toList()
+            datasetRepository.findByOrganizationId(organizationId, pageable).toList()
           }
     }
     result.forEach { it.security = updateSecurityVisibility(it).security }
@@ -1142,7 +1142,7 @@ class DatasetServiceImpl(
     do {
       val datasetList =
           datasetRepository
-              .findByOrganizationIdNoSecurity(organizationUnregistered.organizationId, pageable)
+              .findByOrganizationId(organizationUnregistered.organizationId, pageable)
               .toList()
       datasetRepository.deleteAll(datasetList)
       pageable = pageable.next()

--- a/dataset/src/test/kotlin/com/cosmotech/dataset/service/DatasetServiceImplTests.kt
+++ b/dataset/src/test/kotlin/com/cosmotech/dataset/service/DatasetServiceImplTests.kt
@@ -104,8 +104,7 @@ class DatasetServiceImplTests {
   @Test
   fun `findAllDatasets should return empty list when no dataset exists`() {
     every { organizationService.getVerifiedOrganization(ORGANIZATION_ID) } returns Organization()
-    every { datasetRepository.findByOrganizationIdNoSecurity(any(), any<PageRequest>()) } returns
-        Page.empty()
+    every { datasetRepository.findByOrganizationId(any(), any<PageRequest>()) } returns Page.empty()
 
     val result = datasetService.findAllDatasets(ORGANIZATION_ID, null, null)
     assertEquals(emptyList(), result)


### PR DESCRIPTION
- Rename repository method from findByOrganizationIdNoSecurity to findByOrganizationId
- Remove unnecessarily parenthesis in query