### PR TITLE
Add constraints on Organization

### DIFF
--- a/doc/Models/OrganizationUpdateRequest.md
+++ b/doc/Models/OrganizationUpdateRequest.md
@@ -3,7 +3,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
-| **name** | **String** | the Organization name | [default to null] |
+| **name** | **String** | the Organization name | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/openapi/plantuml/schemas.plantuml
+++ b/openapi/plantuml/schemas.plantuml
@@ -187,7 +187,7 @@ entity OrganizationSecurity {
 }
 
 entity OrganizationUpdateRequest {
-    * name: String
+    name: String
 }
 
 entity QueryResult {

--- a/organization/src/integrationTest/kotlin/com/cosmotech/organization/service/OrganizationServiceIntegrationTest.kt
+++ b/organization/src/integrationTest/kotlin/com/cosmotech/organization/service/OrganizationServiceIntegrationTest.kt
@@ -283,14 +283,26 @@ class OrganizationServiceIntegrationTest : CsmRedisTestBase() {
         val name = "o-connector-test-1"
         val organizationRegistered =
             organizationApiService.createOrganization(makeSimpleOrganizationCreateRequest(name))
+          val newName ="my-new-name"
+          val organizationUpdated =  organizationApiService.updateOrganization(
+              organizationRegistered.id, OrganizationUpdateRequest(newName))
 
-        organizationRegistered.name = "my-new-name"
-        organizationApiService.updateOrganization(
-            organizationRegistered.id, OrganizationUpdateRequest(organizationRegistered.name))
+          assertEquals(
+              newName, organizationApiService.getOrganization(organizationUpdated.id).name)
 
-        assertEquals(
-            organizationRegistered,
-            organizationApiService.getOrganization(organizationRegistered.id))
+          // Update organization with empty body
+          organizationApiService.updateOrganization(
+              organizationUpdated.id, OrganizationUpdateRequest())
+
+          assertEquals(
+              newName, organizationApiService.getOrganization(organizationUpdated.id).name)
+
+          // Update organization with null value as name
+          organizationApiService.updateOrganization(
+              organizationUpdated.id, OrganizationUpdateRequest(null))
+
+          assertEquals(
+              newName, organizationApiService.getOrganization(organizationUpdated.id).name)
       }
     }
 
@@ -306,13 +318,26 @@ class OrganizationServiceIntegrationTest : CsmRedisTestBase() {
 
         runAsOrganizationUser()
 
-        organizationRegistered.name = "my-new-name"
-        organizationApiService.updateOrganization(
-            organizationRegistered.id, OrganizationUpdateRequest(organizationRegistered.name))
+          val newName ="my-new-name"
+          val organizationUpdated =  organizationApiService.updateOrganization(
+              organizationRegistered.id, OrganizationUpdateRequest(newName))
 
-        assertEquals(
-            organizationRegistered,
-            organizationApiService.getOrganization(organizationRegistered.id))
+          assertEquals(
+              newName, organizationApiService.getOrganization(organizationUpdated.id).name)
+
+          // Update organization with empty body
+          organizationApiService.updateOrganization(
+              organizationUpdated.id, OrganizationUpdateRequest())
+
+          assertEquals(
+              newName, organizationApiService.getOrganization(organizationUpdated.id).name)
+
+          // Update organization with null value as name
+          organizationApiService.updateOrganization(
+              organizationUpdated.id, OrganizationUpdateRequest(null))
+
+          assertEquals(
+              newName, organizationApiService.getOrganization(organizationUpdated.id).name)
       }
     }
 
@@ -1214,16 +1239,29 @@ class OrganizationServiceIntegrationTest : CsmRedisTestBase() {
   @Test
   fun `updateOrganization as resource admin organization name`() {
     assertDoesNotThrow {
-      val name = "o-connector-test-1"
-      val organizationRegistered =
-          organizationApiService.createOrganization(makeSimpleOrganizationCreateRequest(name))
 
-      organizationRegistered.name = "my-new-name"
-      organizationApiService.updateOrganization(
-          organizationRegistered.id, OrganizationUpdateRequest("my-new-name"))
+      val organizationRegistered =
+          organizationApiService.createOrganization(makeSimpleOrganizationCreateRequest("o-connector-test-1"))
+        val newName ="my-new-name"
+        val organizationUpdated =  organizationApiService.updateOrganization(
+          organizationRegistered.id, OrganizationUpdateRequest(newName))
 
       assertEquals(
-          organizationRegistered, organizationApiService.getOrganization(organizationRegistered.id))
+          newName, organizationApiService.getOrganization(organizationUpdated.id).name)
+
+        // Update organization with empty body
+        organizationApiService.updateOrganization(
+            organizationUpdated.id, OrganizationUpdateRequest())
+
+        assertEquals(
+            newName, organizationApiService.getOrganization(organizationUpdated.id).name)
+
+        // Update organization with null value as name
+        organizationApiService.updateOrganization(
+            organizationUpdated.id, OrganizationUpdateRequest(null))
+
+        assertEquals(
+            newName, organizationApiService.getOrganization(organizationUpdated.id).name)
     }
   }
 
@@ -1239,12 +1277,26 @@ class OrganizationServiceIntegrationTest : CsmRedisTestBase() {
 
       runAsPlatformAdmin()
 
-      organizationRegistered.name = "my-new-name"
-      organizationApiService.updateOrganization(
-          organizationRegistered.id, OrganizationUpdateRequest(organizationRegistered.name))
+        val newName ="my-new-name"
+        val organizationUpdated =  organizationApiService.updateOrganization(
+            organizationRegistered.id, OrganizationUpdateRequest(newName))
 
-      assertEquals(
-          organizationRegistered, organizationApiService.getOrganization(organizationRegistered.id))
+        assertEquals(
+            newName, organizationApiService.getOrganization(organizationUpdated.id).name)
+
+        // Update organization with empty body
+        organizationApiService.updateOrganization(
+            organizationUpdated.id, OrganizationUpdateRequest())
+
+        assertEquals(
+            newName, organizationApiService.getOrganization(organizationUpdated.id).name)
+
+        // Update organization with null value as name
+        organizationApiService.updateOrganization(
+            organizationUpdated.id, OrganizationUpdateRequest(null))
+
+        assertEquals(
+            newName, organizationApiService.getOrganization(organizationUpdated.id).name)
     }
   }
 
@@ -1256,8 +1308,26 @@ class OrganizationServiceIntegrationTest : CsmRedisTestBase() {
       val organizationRegistered =
           organizationApiService.createOrganization(makeSimpleOrganizationCreateRequest(name))
       runAsPlatformAdmin()
-      organizationApiService.updateOrganization(
-          organizationRegistered.id, OrganizationUpdateRequest("name"))
+        val newName ="my-new-name"
+        val organizationUpdated =  organizationApiService.updateOrganization(
+            organizationRegistered.id, OrganizationUpdateRequest(newName))
+
+        assertEquals(
+            newName, organizationApiService.getOrganization(organizationUpdated.id).name)
+
+        // Update organization with empty body
+        organizationApiService.updateOrganization(
+            organizationUpdated.id, OrganizationUpdateRequest())
+
+        assertEquals(
+            newName, organizationApiService.getOrganization(organizationUpdated.id).name)
+
+        // Update organization with null value as name
+        organizationApiService.updateOrganization(
+            organizationUpdated.id, OrganizationUpdateRequest(null))
+
+        assertEquals(
+            newName, organizationApiService.getOrganization(organizationUpdated.id).name)
     }
   }
 

--- a/organization/src/main/openapi/organization.yaml
+++ b/organization/src/main/openapi/organization.yaml
@@ -469,6 +469,8 @@ components:
           type: string
           x-field-extra-annotation: "@com.redis.om.spring.annotations.Searchable"
           description: the Organization name
+          minLength: 1
+          maxLength: 50
         security:
           $ref: '#/components/schemas/OrganizationSecurity'
       required:
@@ -481,8 +483,8 @@ components:
         name:
           type: string
           description: the Organization name
-      required:
-        - name
+          minLength: 1
+          maxLength: 50
 
     # Security Operation Schemas
     OrganizationSecurity:

--- a/organization/src/test/kotlin/com/cosmotech/organization/service/OrganizationServiceImplTests.kt
+++ b/organization/src/test/kotlin/com/cosmotech/organization/service/OrganizationServiceImplTests.kt
@@ -81,7 +81,7 @@ class OrganizationServiceImplTests {
     val rbacSecurity =
         RbacSecurity(
             organization.id,
-            organization.security.default!!,
+            organization.security.default,
             mutableListOf(RbacAccessControl("ID", ROLE_VIEWER)))
     val rbacAccessControl = RbacAccessControl(USER_ID, ROLE_ADMIN)
     every { organizationRepository.findByIdOrNull(any()) } returns organization
@@ -91,9 +91,9 @@ class OrganizationServiceImplTests {
 
     assertEquals(organization.security.default, rbacSecurity.default)
     assertEquals(
-        organization.security.accessControlList!![0].id, rbacSecurity.accessControlList[0].id)
+        organization.security.accessControlList[0].id, rbacSecurity.accessControlList[0].id)
     assertEquals(
-        organization.security.accessControlList!![0].role, rbacSecurity.accessControlList[0].role)
+        organization.security.accessControlList[0].role, rbacSecurity.accessControlList[0].role)
 
     every { organizationRepository.save(any()) } returns organization
     every { csmRbac.getAccessControl(any(), any()) } returns rbacAccessControl


### PR DESCRIPTION
- organization's name is no longer required for updating an organization
- organization's name should have size between 1 and 50 for creation or update