### PR TITLE
fix: upgrade to python > 3.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ plugins {
   id("com.github.jk1.dependency-license-report") version "2.9"
   id("org.jetbrains.kotlinx.kover") version "0.7.4"
   id("io.gitlab.arturbosch.detekt") version "1.23.7"
-  id("org.openapi.generator") version "7.8.0" apply false
+  id("org.openapi.generator") version "7.10.0" apply false
   id("com.google.cloud.tools.jib") version "3.4.4" apply false
 }
 


### PR DESCRIPTION
we can bring up the openapi-generator to v.7.10.0 (but not to latest stable 7.11 without breaking things).

With this minor upgrade to 7.10.0 the generated python client has as minimum requirement python 3.8 instead of 3.7. Both 3.7 and 3.8 versions have reached their end-of-life but at least 3.8 is still available in the github ubuntu latest runners. With this minor change we will be able to avoid a failed github action in the generated python client