### PR TITLE
Change dataset ACL management when ACL is modified on Scenario

### DIFF
--- a/scenario/src/integrationTest/kotlin/com/cosmotech/scenario/service/ScenarioServiceRBACTest.kt
+++ b/scenario/src/integrationTest/kotlin/com/cosmotech/scenario/service/ScenarioServiceRBACTest.kt
@@ -6044,10 +6044,10 @@ class ScenarioServiceRBACTest : CsmRedisTestBase() {
   @TestFactory
   fun `test Dataset RBAC removeScenarioAccessControl`() =
       mapOf(
-              ROLE_VIEWER to true,
-              ROLE_EDITOR to true,
+              ROLE_VIEWER to false,
+              ROLE_EDITOR to false,
               ROLE_VALIDATOR to true,
-              ROLE_USER to true,
+              ROLE_USER to false,
               ROLE_NONE to true,
               ROLE_ADMIN to false,
           )
@@ -7141,7 +7141,8 @@ class ScenarioServiceRBACTest : CsmRedisTestBase() {
       organizationId: String,
       solutionId: String,
       id: String,
-      role: String
+      role: String,
+      datasetCopy: Boolean = true
   ): Workspace {
     return Workspace(
         key = UUID.randomUUID().toString(),
@@ -7152,6 +7153,7 @@ class ScenarioServiceRBACTest : CsmRedisTestBase() {
             ),
         organizationId = organizationId,
         ownerId = "ownerId",
+        datasetCopy = datasetCopy,
         security =
             WorkspaceSecurity(
                 default = ROLE_NONE,


### PR DESCRIPTION
- Main Dataset linked to a scenario are not modified anymore (except when a user is added into linked Scenario ACL)
- Update and remove a user from a Scenario ACL do not change ACL for linked dataset marked as main
- Not marked dataset are modified to match the linked scenario ACL

Note:
Dataset that are marked as main can be shared between several Scenario, update/remove ACL entries on main dataset lead to permission issues