### PR TITLE
[PROD-13446] Solution.sdkVersion is now retrieved from the docker image

### DIFF
--- a/api/src/integrationTest/kotlin/com/cosmotech/api/home/ControllerTestUtils.kt
+++ b/api/src/integrationTest/kotlin/com/cosmotech/api/home/ControllerTestUtils.kt
@@ -85,7 +85,6 @@ class ControllerTestUtils {
         parameters: MutableList<RunTemplateParameter> = mutableListOf(),
         parameterGroups: MutableList<RunTemplateParameterGroup> = mutableListOf(),
         runTemplates: MutableList<RunTemplate> = mutableListOf(),
-        sdkVersion: String = "",
         url: String = "",
         security: SolutionSecurity? = null
     ): SolutionCreateRequest {
@@ -101,7 +100,6 @@ class ControllerTestUtils {
           parameters = parameters,
           parameterGroups = parameterGroups,
           runTemplates = runTemplates,
-          sdkVersion = sdkVersion,
           url = url,
           security = security,
       )
@@ -117,7 +115,6 @@ class ControllerTestUtils {
         description: String = "",
         alwaysPull: Boolean? = null,
         tags: MutableList<String> = mutableListOf(),
-        sdkVersion: String = "",
         url: String = "",
     ): SolutionUpdateRequest {
       return SolutionUpdateRequest(
@@ -129,7 +126,6 @@ class ControllerTestUtils {
           description = description,
           alwaysPull = alwaysPull,
           tags = tags,
-          sdkVersion = sdkVersion,
           url = url)
     }
   }

--- a/api/src/integrationTest/kotlin/com/cosmotech/api/home/solution/SolutionConstants.kt
+++ b/api/src/integrationTest/kotlin/com/cosmotech/api/home/solution/SolutionConstants.kt
@@ -13,6 +13,7 @@ object SolutionConstants {
   const val SOLUTION_KEY = "my_solution_key"
   const val SOLUTION_REPOSITORY = "solution_repository"
   const val SOLUTION_VERSION = "1.0.0"
+  const val SOLUTION_SDK_VERSION = "11.3.0-45678.abcdef12"
   const val SOLUTION_SIMULATOR = "my_simulator_name"
   const val NEW_USER_ID = "new.user@cosmotech.com"
   const val NEW_USER_ROLE = "editor"

--- a/dataset/src/integrationTest/kotlin/com/cosmotech/dataset/service/DatasetServiceIntegrationTest.kt
+++ b/dataset/src/integrationTest/kotlin/com/cosmotech/dataset/service/DatasetServiceIntegrationTest.kt
@@ -5,6 +5,7 @@
 package com.cosmotech.dataset.service
 
 import com.cosmotech.api.config.CsmPlatformProperties
+import com.cosmotech.api.containerregistry.ContainerRegistryService
 import com.cosmotech.api.events.CsmEventPublisher
 import com.cosmotech.api.events.TwingraphImportEvent
 import com.cosmotech.api.exceptions.CsmAccessForbiddenException
@@ -118,6 +119,7 @@ class DatasetServiceIntegrationTest : CsmRedisTestBase() {
   @Autowired lateinit var workspaceApiService: WorkspaceApiServiceInterface
   @SpykBean @Autowired lateinit var csmPlatformProperties: CsmPlatformProperties
   @MockK(relaxUnitFun = true) lateinit var eventPublisher: CsmEventPublisher
+  private var containerRegistryService: ContainerRegistryService = mockk(relaxed = true)
 
   lateinit var connectorSaved: Connector
   lateinit var dataset: Dataset
@@ -144,6 +146,9 @@ class DatasetServiceIntegrationTest : CsmRedisTestBase() {
     unifiedJedis = UnifiedJedis(HostAndPort(containerIp, Protocol.DEFAULT_PORT))
     ReflectionTestUtils.setField(datasetApiService, "unifiedJedis", unifiedJedis)
     ReflectionTestUtils.setField(datasetApiService, "eventPublisher", eventPublisher)
+    ReflectionTestUtils.setField(
+        solutionApiService, "containerRegistryService", containerRegistryService)
+    every { containerRegistryService.getImageLabel(any(), any(), any()) } returns null
   }
 
   @BeforeEach

--- a/doc/Models/Solution.md
+++ b/doc/Models/Solution.md
@@ -13,7 +13,7 @@
 | **csmSimulator** | **String** | The main Cosmo Tech simulator name used in standard Run Template | [default to null] |
 | **version** | **String** | The Solution version MAJOR.MINOR.PATCH. Must be aligned with an existing repository tag | [default to null] |
 | **ownerId** | **String** | The User id which owns this Solution | [default to null] |
-| **sdkVersion** | **String** | The MAJOR.MINOR version used to build this solution | [optional] [default to null] |
+| **sdkVersion** | **String** | The full SDK version used to build this solution, if available | [optional] [default to null] |
 | **url** | **String** | An optional URL link to solution page | [optional] [default to null] |
 | **tags** | **List** | The list of tags | [optional] [default to null] |
 | **parameters** | [**List**](RunTemplateParameter.md) | The list of Run Template Parameters | [default to null] |

--- a/doc/Models/SolutionCreateRequest.md
+++ b/doc/Models/SolutionCreateRequest.md
@@ -14,7 +14,6 @@
 | **parameters** | [**List**](RunTemplateParameter.md) | The list of Run Template Parameters | [optional] [default to []] |
 | **parameterGroups** | [**List**](RunTemplateParameterGroup.md) | The list of parameters groups for the Run Templates | [optional] [default to []] |
 | **runTemplates** | [**List**](RunTemplate.md) | List of Run Templates | [optional] [default to []] |
-| **sdkVersion** | **String** | The MAJOR.MINOR version used to build this solution | [optional] [default to null] |
 | **url** | **String** | An optional URL link to solution page | [optional] [default to null] |
 | **security** | [**SolutionSecurity**](SolutionSecurity.md) |  | [optional] [default to null] |
 

--- a/doc/Models/SolutionUpdateRequest.md
+++ b/doc/Models/SolutionUpdateRequest.md
@@ -10,7 +10,6 @@
 | **alwaysPull** | **Boolean** | Set to true if the runtemplate wants to always pull the image | [optional] [default to false] |
 | **csmSimulator** | **String** | The main Cosmo Tech simulator name used in standard Run Template | [optional] [default to null] |
 | **version** | **String** | The Solution version MAJOR.MINOR.PATCH. Must be aligned with an existing repository tag | [optional] [default to null] |
-| **sdkVersion** | **String** | The MAJOR.MINOR version used to build this solution | [optional] [default to null] |
 | **url** | **String** | An optional URL link to solution page | [optional] [default to null] |
 | **tags** | **List** | The list of tags | [optional] [default to null] |
 

--- a/openapi/plantuml/schemas.plantuml
+++ b/openapi/plantuml/schemas.plantuml
@@ -470,7 +470,6 @@ entity SolutionCreateRequest {
     parameters: List<RunTemplateParameter>
     parameterGroups: List<RunTemplateParameterGroup>
     runTemplates: List<RunTemplate>
-    sdkVersion: String
     url: String
     security: SolutionSecurity
 }
@@ -492,7 +491,6 @@ entity SolutionUpdateRequest {
     alwaysPull: Boolean
     csmSimulator: String
     version: String
-    sdkVersion: String
     url: String
     tags: List<String>
 }

--- a/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceIntegrationTest.kt
+++ b/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceIntegrationTest.kt
@@ -5,6 +5,7 @@
 package com.cosmotech.runner.service
 
 import com.cosmotech.api.config.CsmPlatformProperties
+import com.cosmotech.api.containerregistry.ContainerRegistryService
 import com.cosmotech.api.events.CsmEventPublisher
 import com.cosmotech.api.events.HasRunningRuns
 import com.cosmotech.api.events.RunStart
@@ -53,6 +54,7 @@ import com.redis.om.spring.RediSearchIndexer
 import com.redis.testcontainers.RedisStackContainer
 import io.mockk.every
 import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import java.time.Instant
 import java.util.*
@@ -105,6 +107,8 @@ class RunnerServiceIntegrationTest : CsmRedisTestBase() {
   @Autowired lateinit var runnerApiService: RunnerApiServiceInterface
   @Autowired lateinit var csmPlatformProperties: CsmPlatformProperties
 
+  private var containerRegistryService: ContainerRegistryService = mockk(relaxed = true)
+
   lateinit var connector: Connector
   lateinit var dataset: Dataset
   lateinit var solution: SolutionCreateRequest
@@ -142,6 +146,9 @@ class RunnerServiceIntegrationTest : CsmRedisTestBase() {
     jedis = UnifiedJedis(HostAndPort(containerIp, Protocol.DEFAULT_PORT))
 
     ReflectionTestUtils.setField(datasetApiService, "unifiedJedis", jedis)
+    ReflectionTestUtils.setField(
+        solutionApiService, "containerRegistryService", containerRegistryService)
+    every { containerRegistryService.getImageLabel(any(), any(), any()) } returns null
   }
 
   @BeforeEach

--- a/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceRBACTest.kt
+++ b/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceRBACTest.kt
@@ -5,6 +5,7 @@
 package com.cosmotech.runner.service
 
 import com.cosmotech.api.config.CsmPlatformProperties
+import com.cosmotech.api.containerregistry.ContainerRegistryService
 import com.cosmotech.api.exceptions.CsmAccessForbiddenException
 import com.cosmotech.api.rbac.PERMISSION_CREATE_CHILDREN
 import com.cosmotech.api.rbac.PERMISSION_DELETE
@@ -108,6 +109,8 @@ class RunnerServiceRBACTest : CsmRedisTestBase() {
   @Autowired lateinit var runnerApiService: RunnerApiService
   @Autowired lateinit var csmPlatformProperties: CsmPlatformProperties
 
+  private var containerRegistryService: ContainerRegistryService = mockk(relaxed = true)
+
   lateinit var jedis: UnifiedJedis
 
   @BeforeEach
@@ -128,6 +131,9 @@ class RunnerServiceRBACTest : CsmRedisTestBase() {
         (context.server as RedisStackContainer).containerInfo.networkSettings.ipAddress
     jedis = UnifiedJedis(HostAndPort(containerIp, Protocol.DEFAULT_PORT))
     ReflectionTestUtils.setField(datasetApiService, "unifiedJedis", jedis)
+    ReflectionTestUtils.setField(
+        solutionApiService, "containerRegistryService", containerRegistryService)
+    every { containerRegistryService.getImageLabel(any(), any(), any()) } returns null
   }
 
   @TestFactory

--- a/solution/src/integrationTest/kotlin/com/cosmotech/solution/service/SolutionServiceRBACTest.kt
+++ b/solution/src/integrationTest/kotlin/com/cosmotech/solution/service/SolutionServiceRBACTest.kt
@@ -3,6 +3,7 @@
 package com.cosmotech.solution.service
 
 import com.cosmotech.api.config.CsmPlatformProperties
+import com.cosmotech.api.containerregistry.ContainerRegistryService
 import com.cosmotech.api.exceptions.CsmAccessForbiddenException
 import com.cosmotech.api.rbac.PERMISSION_CREATE_CHILDREN
 import com.cosmotech.api.rbac.PERMISSION_DELETE
@@ -39,6 +40,7 @@ import com.redis.om.spring.RediSearchIndexer
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import java.io.InputStream
 import java.util.*
@@ -56,6 +58,7 @@ import org.springframework.core.io.Resource
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.util.ReflectionTestUtils
 
 @ActiveProfiles(profiles = ["solution-test"])
 @ExtendWith(MockKExtension::class)
@@ -74,6 +77,8 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
 
   @Autowired lateinit var csmPlatformProperties: CsmPlatformProperties
 
+  private var containerRegistryService: ContainerRegistryService = mockk(relaxed = true)
+
   lateinit var organization: OrganizationCreateRequest
   lateinit var solution: SolutionCreateRequest
 
@@ -87,6 +92,9 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
   @BeforeEach
   fun setUp() {
     mockkStatic("com.cosmotech.api.utils.SecurityUtilsKt")
+    ReflectionTestUtils.setField(
+        solutionApiService, "containerRegistryService", containerRegistryService)
+    every { containerRegistryService.getImageLabel(any(), any(), any()) } returns null
     every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
     every { getCurrentAuthenticatedUserName(csmPlatformProperties) } returns "test.user"
     every { getCurrentAuthenticatedRoles(any()) } returns listOf("user")

--- a/solution/src/main/openapi/solution.yaml
+++ b/solution/src/main/openapi/solution.yaml
@@ -729,8 +729,8 @@ components:
           description: The User id which owns this Solution
         sdkVersion:
           type: string
-          description: The MAJOR.MINOR version used to build this solution
-          example: "2.4"
+          description: The full SDK version used to build this solution, if available
+          example: 11.3.0-39929.27365ede
         url:
           type: string
           description: An optional URL link to solution page
@@ -839,10 +839,6 @@ components:
           description: List of Run Templates
           items:
             $ref: '#/components/schemas/RunTemplate'
-        sdkVersion:
-          type: string
-          description: The MAJOR.MINOR version used to build this solution
-          example: "2.4"
         url:
           type: string
           description: An optional URL link to solution page
@@ -895,10 +891,6 @@ components:
           description: The Solution version MAJOR.MINOR.PATCH. Must be aligned with an existing repository tag
           minLength: 1
           example: "1.0.0"
-        sdkVersion:
-          type: string
-          description: The MAJOR.MINOR version used to build this solution
-          example: "2.4"
         url:
           type: string
           description: An optional URL link to solution page

--- a/workspace/src/integrationTest/kotlin/com/cosmotech/workspace/service/WorkspaceServiceIntegrationTest.kt
+++ b/workspace/src/integrationTest/kotlin/com/cosmotech/workspace/service/WorkspaceServiceIntegrationTest.kt
@@ -3,6 +3,7 @@
 package com.cosmotech.workspace.service
 
 import com.cosmotech.api.config.CsmPlatformProperties
+import com.cosmotech.api.containerregistry.ContainerRegistryService
 import com.cosmotech.api.exceptions.CsmAccessForbiddenException
 import com.cosmotech.api.exceptions.CsmResourceNotFoundException
 import com.cosmotech.api.rbac.ROLE_ADMIN
@@ -47,6 +48,7 @@ import com.cosmotech.workspace.domain.WorkspaceWebApp
 import com.redis.om.spring.RediSearchIndexer
 import io.mockk.every
 import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import java.util.*
 import kotlin.test.assertEquals
@@ -64,6 +66,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.context.junit4.SpringRunner
+import org.springframework.test.util.ReflectionTestUtils
 
 @ActiveProfiles(profiles = ["workspace-test"])
 @ExtendWith(MockKExtension::class)
@@ -85,6 +88,8 @@ class WorkspaceServiceIntegrationTest : CsmRedisTestBase() {
   @Autowired lateinit var datasetApiService: DatasetApiService
   @Autowired lateinit var csmPlatformProperties: CsmPlatformProperties
 
+  private var containerRegistryService: ContainerRegistryService = mockk(relaxed = true)
+
   lateinit var organization: OrganizationCreateRequest
   lateinit var solution: SolutionCreateRequest
   lateinit var workspace: WorkspaceCreateRequest
@@ -100,6 +105,8 @@ class WorkspaceServiceIntegrationTest : CsmRedisTestBase() {
   @BeforeEach
   fun setUp() {
     mockkStatic("com.cosmotech.api.utils.SecurityUtilsKt")
+    ReflectionTestUtils.setField(
+        solutionApiService, "containerRegistryService", containerRegistryService)
     every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
     every { getCurrentAuthenticatedUserName(csmPlatformProperties) } returns "test.user"
     every { getCurrentAuthenticatedRoles(any()) } returns listOf("user")

--- a/workspace/src/integrationTest/kotlin/com/cosmotech/workspace/service/WorkspaceServiceRBACTest.kt
+++ b/workspace/src/integrationTest/kotlin/com/cosmotech/workspace/service/WorkspaceServiceRBACTest.kt
@@ -3,6 +3,7 @@
 package com.cosmotech.workspace.service
 
 import com.cosmotech.api.config.CsmPlatformProperties
+import com.cosmotech.api.containerregistry.ContainerRegistryService
 import com.cosmotech.api.exceptions.CsmAccessForbiddenException
 import com.cosmotech.api.rbac.PERMISSION_CREATE_CHILDREN
 import com.cosmotech.api.rbac.PERMISSION_DELETE
@@ -45,6 +46,7 @@ import com.redis.om.spring.RediSearchIndexer
 import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import java.io.File
 import java.nio.file.Files
@@ -88,9 +90,14 @@ class WorkspaceServiceRBACTest : CsmRedisTestBase() {
   @Autowired lateinit var workspaceApiService: WorkspaceApiServiceInterface
   @Autowired lateinit var csmPlatformProperties: CsmPlatformProperties
 
+  private var containerRegistryService: ContainerRegistryService = mockk(relaxed = true)
+
   @BeforeEach
   fun beforeEach() {
     mockkStatic("com.cosmotech.api.utils.SecurityUtilsKt")
+    ReflectionTestUtils.setField(
+        solutionApiService, "containerRegistryService", containerRegistryService)
+    every { containerRegistryService.getImageLabel(any(), any(), any()) } returns null
     every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
     every { getCurrentAuthenticatedUserName(csmPlatformProperties) } returns "test.user"
     every { getCurrentAuthenticatedRoles(any()) } returns listOf()


### PR DESCRIPTION
The field is now read only and is 'computed' at runtime from a label on the docker image.
This requires the solution image heving been built with a SDK version 11.3.0 or newer, but it should be relatively easy to manually add the required label ('com.cosmotech.sdk-version') with older SDK version