### PR TITLE
Add crud on solution run templates

### DIFF
--- a/api/src/integrationTest/kotlin/com/cosmotech/api/home/ControllerTestUtils.kt
+++ b/api/src/integrationTest/kotlin/com/cosmotech/api/home/ControllerTestUtils.kt
@@ -84,7 +84,7 @@ class ControllerTestUtils {
         tags: MutableList<String> = mutableListOf(),
         parameters: MutableList<RunTemplateParameterCreateRequest> = mutableListOf(),
         parameterGroups: MutableList<RunTemplateParameterGroupCreateRequest> = mutableListOf(),
-        runTemplates: MutableList<RunTemplate> = mutableListOf(),
+        runTemplates: MutableList<RunTemplateCreateRequest> = mutableListOf(),
         url: String = "",
         security: SolutionSecurity? = null
     ): SolutionCreateRequest {

--- a/api/src/integrationTest/kotlin/com/cosmotech/api/home/run/RunControllerTests.kt
+++ b/api/src/integrationTest/kotlin/com/cosmotech/api/home/run/RunControllerTests.kt
@@ -56,7 +56,7 @@ import com.cosmotech.run.domain.*
 import com.cosmotech.run.workflow.WorkflowService
 import com.cosmotech.runner.domain.*
 import com.cosmotech.runner.domain.ResourceSizeInfo
-import com.cosmotech.solution.domain.RunTemplate
+import com.cosmotech.solution.domain.RunTemplateCreateRequest
 import com.cosmotech.solution.domain.RunTemplateResourceSizing
 import com.ninjasquad.springmockk.SpykBean
 import io.mockk.every
@@ -111,7 +111,7 @@ class RunControllerTests : ControllerTestBase() {
 
     val runTemplates =
         mutableListOf(
-            RunTemplate(
+            RunTemplateCreateRequest(
                 RUNNER_RUN_TEMPLATE,
                 RUN_TEMPLATE_NAME,
                 PARAMETER_LABELS,

--- a/api/src/integrationTest/kotlin/com/cosmotech/api/home/runner/RunnerControllerTests.kt
+++ b/api/src/integrationTest/kotlin/com/cosmotech/api/home/runner/RunnerControllerTests.kt
@@ -28,7 +28,7 @@ import com.cosmotech.api.rbac.ROLE_NONE
 import com.cosmotech.api.rbac.ROLE_VIEWER
 import com.cosmotech.runner.domain.*
 import com.cosmotech.runner.domain.ResourceSizeInfo
-import com.cosmotech.solution.domain.RunTemplate
+import com.cosmotech.solution.domain.RunTemplateCreateRequest
 import com.cosmotech.solution.domain.RunTemplateResourceSizing
 import com.ninjasquad.springmockk.SpykBean
 import io.mockk.every
@@ -73,7 +73,7 @@ class RunnerControllerTests : ControllerTestBase() {
             com.cosmotech.solution.domain.ResourceSizeInfo("cpu_limits", "memory_limits"))
     val runTemplates =
         mutableListOf(
-            RunTemplate(
+            RunTemplateCreateRequest(
                 RUNNER_RUN_TEMPLATE,
                 runTemplateName,
                 parameterLabels,

--- a/api/src/integrationTest/kotlin/com/cosmotech/api/home/solution/SolutionControllerTests.kt
+++ b/api/src/integrationTest/kotlin/com/cosmotech/api/home/solution/SolutionControllerTests.kt
@@ -973,6 +973,56 @@ class SolutionControllerTests : ControllerTestBase() {
 
   @Test
   @WithMockOauth2User
+  fun list_solution_runTemplate() {
+    val runTemplateId = "runtemplate1"
+
+    val runTemplateName = "this_is_a_name"
+    val runTemplateLabels = mutableMapOf("fr" to "this_is_a_label")
+    val runTemplateDescription = "this_is_a_description"
+    val runTemplateTags = mutableListOf("tag1", "tag2")
+    val runTemplateComputeSize = "this_is_a_compute_size"
+    val runTemplateParameterGroups = mutableListOf("parameterGroup1")
+    val runTemplates =
+        mutableListOf(
+            RunTemplateCreateRequest(
+                runTemplateId,
+                runTemplateName,
+                runTemplateLabels,
+                runTemplateDescription,
+                runTemplateTags,
+                runTemplateComputeSize,
+                RunTemplateResourceSizing(
+                    ResourceSizeInfo("cpu_requests", "memory_requests"),
+                    ResourceSizeInfo("cpu_limits", "memory_limits")),
+                runTemplateParameterGroups,
+                10))
+
+    val solutionId =
+        createSolutionAndReturnId(
+            mvc, organizationId, constructSolutionCreateRequest(runTemplates = runTemplates))
+
+    mvc.perform(
+            get("/organizations/$organizationId/solutions/$solutionId/runTemplates")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().is2xxSuccessful)
+        .andExpect(jsonPath("$[0].id").value(runTemplateId))
+        .andExpect(jsonPath("$[0].name").value(runTemplateName))
+        .andExpect(jsonPath("$[0].labels").value(runTemplateLabels))
+        .andExpect(jsonPath("$[0].description").value(runTemplateDescription))
+        .andExpect(jsonPath("$[0].tags").value(runTemplateTags))
+        .andExpect(jsonPath("$[0].computeSize").value(runTemplateComputeSize))
+        .andExpect(jsonPath("$[0].runSizing.requests.cpu").value("cpu_requests"))
+        .andExpect(jsonPath("$[0].runSizing.requests.memory").value("memory_requests"))
+        .andExpect(jsonPath("$[0].runSizing.limits.cpu").value("cpu_limits"))
+        .andExpect(jsonPath("$[0].runSizing.limits.memory").value("memory_limits"))
+        .andExpect(jsonPath("$[0].parameterGroups").value(runTemplateParameterGroups))
+        .andExpect(jsonPath("$[0].executionTimeout").value(10))
+        .andDo(MockMvcResultHandlers.print())
+        .andDo(document("organizations/{organization_id}/solutions/{solution_id}/runTemplates/GET"))
+  }
+
+  @Test
+  @WithMockOauth2User
   fun create_solution_runTemplate() {
 
     val description = "this_is_a_description"
@@ -1026,30 +1076,28 @@ class SolutionControllerTests : ControllerTestBase() {
 
   @Test
   @WithMockOauth2User
-  fun delete_solution_runTemplate() {
-
-    val description = "this_is_a_description"
-    val tags = mutableListOf("tag1", "tag2")
-    val parameterLabels = mutableMapOf("fr" to "this_is_a_label")
-    val parameterGroupId = "parameterGroup1"
+  fun get_solution_runTemplate() {
     val runTemplateId = "runtemplate1"
+
     val runTemplateName = "this_is_a_name"
+    val runTemplateLabels = mutableMapOf("fr" to "this_is_a_label")
+    val runTemplateDescription = "this_is_a_description"
+    val runTemplateTags = mutableListOf("tag1", "tag2")
     val runTemplateComputeSize = "this_is_a_compute_size"
-    val runTemplateRunSizing =
-        RunTemplateResourceSizing(
-            ResourceSizeInfo("cpu_requests", "memory_requests"),
-            ResourceSizeInfo("cpu_limits", "memory_limits"))
+    val runTemplateParameterGroups = mutableListOf("parameterGroup1")
     val runTemplates =
         mutableListOf(
             RunTemplateCreateRequest(
                 runTemplateId,
                 runTemplateName,
-                parameterLabels,
-                description,
-                tags,
+                runTemplateLabels,
+                runTemplateDescription,
+                runTemplateTags,
                 runTemplateComputeSize,
-                runTemplateRunSizing,
-                mutableListOf(parameterGroupId),
+                RunTemplateResourceSizing(
+                    ResourceSizeInfo("cpu_requests", "memory_requests"),
+                    ResourceSizeInfo("cpu_limits", "memory_limits")),
+                runTemplateParameterGroups,
                 10))
 
     val solutionId =
@@ -1057,15 +1105,25 @@ class SolutionControllerTests : ControllerTestBase() {
             mvc, organizationId, constructSolutionCreateRequest(runTemplates = runTemplates))
 
     mvc.perform(
-            delete(
-                    "/organizations/$organizationId/solutions/$solutionId/runTemplates/$runTemplateId")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(csrf()))
+            get("/organizations/$organizationId/solutions/$solutionId/runTemplates/$runTemplateId")
+                .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful)
+        .andExpect(jsonPath("$.id").value(runTemplateId))
+        .andExpect(jsonPath("$.name").value(runTemplateName))
+        .andExpect(jsonPath("$.labels").value(runTemplateLabels))
+        .andExpect(jsonPath("$.description").value(runTemplateDescription))
+        .andExpect(jsonPath("$.tags").value(runTemplateTags))
+        .andExpect(jsonPath("$.computeSize").value(runTemplateComputeSize))
+        .andExpect(jsonPath("$.runSizing.requests.cpu").value("cpu_requests"))
+        .andExpect(jsonPath("$.runSizing.requests.memory").value("memory_requests"))
+        .andExpect(jsonPath("$.runSizing.limits.cpu").value("cpu_limits"))
+        .andExpect(jsonPath("$.runSizing.limits.memory").value("memory_limits"))
+        .andExpect(jsonPath("$.parameterGroups").value(runTemplateParameterGroups))
+        .andExpect(jsonPath("$.executionTimeout").value(10))
         .andDo(MockMvcResultHandlers.print())
         .andDo(
             document(
-                "organizations/{organization_id}/solutions/{solution_id}/runTemplates/{run_template_id}/DELETE"))
+                "organizations/{organization_id}/solutions/{solution_id}/runTemplates/{run_template_id}/GET"))
   }
 
   @Test
@@ -1120,22 +1178,66 @@ class SolutionControllerTests : ControllerTestBase() {
                 .contentType(MediaType.APPLICATION_JSON)
                 .with(csrf()))
         .andExpect(status().is2xxSuccessful)
-        .andExpect(jsonPath("$[0].id").value(runTemplateId))
-        .andExpect(jsonPath("$[0].name").value(runTemplateName))
-        .andExpect(jsonPath("$[0].labels").value(parameterLabels))
-        .andExpect(jsonPath("$[0].description").value(description))
-        .andExpect(jsonPath("$[0].tags").value(tags))
-        .andExpect(jsonPath("$[0].computeSize").value(runTemplateComputeSize))
-        .andExpect(jsonPath("$[0].runSizing.requests.cpu").value("cpu_requests2"))
-        .andExpect(jsonPath("$[0].runSizing.requests.memory").value("memory_requests2"))
-        .andExpect(jsonPath("$[0].runSizing.limits.cpu").value("cpu_limits2"))
-        .andExpect(jsonPath("$[0].runSizing.limits.memory").value("memory_limits2"))
-        .andExpect(jsonPath("$[0].parameterGroups").value(mutableListOf(parameterGroupId)))
-        .andExpect(jsonPath("$[0].executionTimeout").value(100))
+        .andExpect(jsonPath("$.id").value(runTemplateId))
+        .andExpect(jsonPath("$.name").value(runTemplateName))
+        .andExpect(jsonPath("$.labels").value(parameterLabels))
+        .andExpect(jsonPath("$.description").value(description))
+        .andExpect(jsonPath("$.tags").value(tags))
+        .andExpect(jsonPath("$.computeSize").value(runTemplateComputeSize))
+        .andExpect(jsonPath("$.runSizing.requests.cpu").value("cpu_requests2"))
+        .andExpect(jsonPath("$.runSizing.requests.memory").value("memory_requests2"))
+        .andExpect(jsonPath("$.runSizing.limits.cpu").value("cpu_limits2"))
+        .andExpect(jsonPath("$.runSizing.limits.memory").value("memory_limits2"))
+        .andExpect(jsonPath("$.parameterGroups").value(mutableListOf(parameterGroupId)))
+        .andExpect(jsonPath("$.executionTimeout").value(100))
         .andDo(MockMvcResultHandlers.print())
         .andDo(
             document(
                 "organizations/{organization_id}/solutions/{solution_id}/runTemplates/{run_template_id}/PATCH"))
+  }
+
+  @Test
+  @WithMockOauth2User
+  fun delete_solution_runTemplate() {
+
+    val description = "this_is_a_description"
+    val tags = mutableListOf("tag1", "tag2")
+    val parameterLabels = mutableMapOf("fr" to "this_is_a_label")
+    val parameterGroupId = "parameterGroup1"
+    val runTemplateId = "runtemplate1"
+    val runTemplateName = "this_is_a_name"
+    val runTemplateComputeSize = "this_is_a_compute_size"
+    val runTemplateRunSizing =
+        RunTemplateResourceSizing(
+            ResourceSizeInfo("cpu_requests", "memory_requests"),
+            ResourceSizeInfo("cpu_limits", "memory_limits"))
+    val runTemplates =
+        mutableListOf(
+            RunTemplateCreateRequest(
+                runTemplateId,
+                runTemplateName,
+                parameterLabels,
+                description,
+                tags,
+                runTemplateComputeSize,
+                runTemplateRunSizing,
+                mutableListOf(parameterGroupId),
+                10))
+
+    val solutionId =
+        createSolutionAndReturnId(
+            mvc, organizationId, constructSolutionCreateRequest(runTemplates = runTemplates))
+
+    mvc.perform(
+            delete(
+                    "/organizations/$organizationId/solutions/$solutionId/runTemplates/$runTemplateId")
+                .contentType(MediaType.APPLICATION_JSON)
+                .with(csrf()))
+        .andExpect(status().is2xxSuccessful)
+        .andDo(MockMvcResultHandlers.print())
+        .andDo(
+            document(
+                "organizations/{organization_id}/solutions/{solution_id}/runTemplates/{run_template_id}/DELETE"))
   }
 
   @Test

--- a/api/src/integrationTest/kotlin/com/cosmotech/api/home/solution/SolutionControllerTests.kt
+++ b/api/src/integrationTest/kotlin/com/cosmotech/api/home/solution/SolutionControllerTests.kt
@@ -26,7 +26,6 @@ import com.cosmotech.solution.api.SolutionApiService
 import com.cosmotech.solution.domain.*
 import io.mockk.every
 import io.mockk.mockk
-import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -162,7 +161,7 @@ class SolutionControllerTests : ControllerTestBase() {
             ResourceSizeInfo("cpu_limits", "memory_limits"))
     val runTemplates =
         mutableListOf(
-            RunTemplate(
+            RunTemplateCreateRequest(
                 runTemplateId,
                 runTemplateName,
                 parameterLabels,
@@ -300,7 +299,7 @@ class SolutionControllerTests : ControllerTestBase() {
             ResourceSizeInfo("cpu_limits", "memory_limits"))
     val runTemplates =
         mutableListOf(
-            RunTemplate(
+            RunTemplateCreateRequest(
                 runTemplateId,
                 runTemplateName,
                 parameterLabels,
@@ -974,7 +973,7 @@ class SolutionControllerTests : ControllerTestBase() {
 
   @Test
   @WithMockOauth2User
-  fun add_solution_runTemplates() {
+  fun create_solution_runTemplate() {
 
     val description = "this_is_a_description"
     val tags = mutableListOf("tag1", "tag2")
@@ -987,85 +986,42 @@ class SolutionControllerTests : ControllerTestBase() {
         RunTemplateResourceSizing(
             ResourceSizeInfo("cpu_requests", "memory_requests"),
             ResourceSizeInfo("cpu_limits", "memory_limits"))
-    val runTemplates =
-        mutableListOf(
-            RunTemplate(
-                runTemplateId,
-                runTemplateName,
-                parameterLabels,
-                description,
-                tags,
-                runTemplateComputeSize,
-                runTemplateRunSizing,
-                mutableListOf(parameterGroupId),
-                10))
+    val runTemplate =
+        RunTemplateCreateRequest(
+            runTemplateId,
+            runTemplateName,
+            parameterLabels,
+            description,
+            tags,
+            runTemplateComputeSize,
+            runTemplateRunSizing,
+            mutableListOf(parameterGroupId),
+            10)
 
     val solutionId =
         createSolutionAndReturnId(mvc, organizationId, constructSolutionCreateRequest())
 
     mvc.perform(
-            patch("/organizations/$organizationId/solutions/$solutionId/runTemplates")
+            post("/organizations/$organizationId/solutions/$solutionId/runTemplates")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(JSONArray(runTemplates).toString())
+                .content(JSONObject(runTemplate).toString())
                 .with(csrf()))
         .andExpect(status().is2xxSuccessful)
-        .andExpect(jsonPath("$[0].id").value(runTemplateId))
-        .andExpect(jsonPath("$[0].name").value(runTemplateName))
-        .andExpect(jsonPath("$[0].labels").value(parameterLabels))
-        .andExpect(jsonPath("$[0].description").value(description))
-        .andExpect(jsonPath("$[0].tags").value(tags))
-        .andExpect(jsonPath("$[0].computeSize").value(runTemplateComputeSize))
-        .andExpect(jsonPath("$[0].runSizing.requests.cpu").value("cpu_requests"))
-        .andExpect(jsonPath("$[0].runSizing.requests.memory").value("memory_requests"))
-        .andExpect(jsonPath("$[0].runSizing.limits.cpu").value("cpu_limits"))
-        .andExpect(jsonPath("$[0].runSizing.limits.memory").value("memory_limits"))
-        .andExpect(jsonPath("$[0].parameterGroups").value(mutableListOf(parameterGroupId)))
-        .andExpect(jsonPath("$[0].executionTimeout").value(10))
+        .andExpect(jsonPath("$.id").value(runTemplateId))
+        .andExpect(jsonPath("$.name").value(runTemplateName))
+        .andExpect(jsonPath("$.labels").value(parameterLabels))
+        .andExpect(jsonPath("$.description").value(description))
+        .andExpect(jsonPath("$.tags").value(tags))
+        .andExpect(jsonPath("$.computeSize").value(runTemplateComputeSize))
+        .andExpect(jsonPath("$.runSizing.requests.cpu").value("cpu_requests"))
+        .andExpect(jsonPath("$.runSizing.requests.memory").value("memory_requests"))
+        .andExpect(jsonPath("$.runSizing.limits.cpu").value("cpu_limits"))
+        .andExpect(jsonPath("$.runSizing.limits.memory").value("memory_limits"))
+        .andExpect(jsonPath("$.parameterGroups").value(mutableListOf(parameterGroupId)))
+        .andExpect(jsonPath("$.executionTimeout").value(10))
         .andDo(MockMvcResultHandlers.print())
         .andDo(
-            document("organizations/{organization_id}/solutions/{solution_id}/runTemplates/PATCH"))
-  }
-
-  @Test
-  @WithMockOauth2User
-  fun delete_solution_runTemplates() {
-
-    val description = "this_is_a_description"
-    val tags = mutableListOf("tag1", "tag2")
-    val parameterLabels = mutableMapOf("fr" to "this_is_a_label")
-    val parameterGroupId = "parameterGroup1"
-    val runTemplateId = "runtemplate1"
-    val runTemplateName = "this_is_a_name"
-    val runTemplateComputeSize = "this_is_a_compute_size"
-    val runTemplateRunSizing =
-        RunTemplateResourceSizing(
-            ResourceSizeInfo("cpu_requests", "memory_requests"),
-            ResourceSizeInfo("cpu_limits", "memory_limits"))
-    val runTemplates =
-        mutableListOf(
-            RunTemplate(
-                runTemplateId,
-                runTemplateName,
-                parameterLabels,
-                description,
-                tags,
-                runTemplateComputeSize,
-                runTemplateRunSizing,
-                mutableListOf(parameterGroupId),
-                10))
-
-    val solutionId =
-        createSolutionAndReturnId(
-            mvc, organizationId, constructSolutionCreateRequest(runTemplates = runTemplates))
-
-    mvc.perform(
-            delete("/organizations/$organizationId/solutions/$solutionId/runTemplates")
-                .contentType(MediaType.APPLICATION_JSON)
-                .with(csrf()))
-        .andExpect(status().is2xxSuccessful)
-        .andDo(MockMvcResultHandlers.print())
-        .andDo(
-            document("organizations/{organization_id}/solutions/{solution_id}/runTemplates/DELETE"))
+            document("organizations/{organization_id}/solutions/{solution_id}/runTemplates/POST"))
   }
 
   @Test
@@ -1085,7 +1041,7 @@ class SolutionControllerTests : ControllerTestBase() {
             ResourceSizeInfo("cpu_limits", "memory_limits"))
     val runTemplates =
         mutableListOf(
-            RunTemplate(
+            RunTemplateCreateRequest(
                 runTemplateId,
                 runTemplateName,
                 parameterLabels,
@@ -1119,7 +1075,7 @@ class SolutionControllerTests : ControllerTestBase() {
 
     val runTemplates =
         mutableListOf(
-            RunTemplate(
+            RunTemplateCreateRequest(
                 runTemplateId,
                 "this_is_a_name",
                 mutableMapOf("fr" to "this_is_a_label"),
@@ -1147,8 +1103,7 @@ class SolutionControllerTests : ControllerTestBase() {
             ResourceSizeInfo("cpu_requests2", "memory_requests2"),
             ResourceSizeInfo("cpu_limits2", "memory_limits2"))
     val newRunTemplate =
-        RunTemplate(
-            runTemplateId,
+        RunTemplateUpdateRequest(
             runTemplateName,
             parameterLabels,
             description,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -549,6 +549,18 @@ subprojects {
   }
 }
 
+tasks.getByName("spotlessJava") {
+  dependsOn(":cosmotech-api:openApiMarkdownGenerate", ":cosmotech-api:openApiUmlGenerate")
+}
+
+tasks.getByName("spotlessKotlin") {
+  dependsOn(":cosmotech-api:openApiMarkdownGenerate", ":cosmotech-api:openApiUmlGenerate")
+}
+
+tasks.getByName("spotlessKotlinGradle") {
+  dependsOn(":cosmotech-api:openApiMarkdownGenerate", ":cosmotech-api:openApiUmlGenerate")
+}
+
 val copySubProjectsDetektReportsTasks =
     subprojects.flatMap { subProject ->
       listOf("html", "xml", "txt", "sarif").map { format ->

--- a/dataset/src/integrationTest/kotlin/com/cosmotech/dataset/service/DatasetServiceIntegrationTest.kt
+++ b/dataset/src/integrationTest/kotlin/com/cosmotech/dataset/service/DatasetServiceIntegrationTest.kt
@@ -1148,7 +1148,7 @@ class DatasetServiceIntegrationTest : CsmRedisTestBase() {
       SolutionCreateRequest(
           key = UUID.randomUUID().toString(),
           name = "My solution",
-          runTemplates = mutableListOf(RunTemplate("template")),
+          runTemplates = mutableListOf(RunTemplateCreateRequest("template")),
           csmSimulator = "simulator",
           repository = "repository",
           parameterGroups = mutableListOf(RunTemplateParameterGroupCreateRequest("group")),

--- a/doc/.openapi-generator/FILES
+++ b/doc/.openapi-generator/FILES
@@ -50,6 +50,7 @@ Models/RunState.md
 Models/RunStatus.md
 Models/RunStatusNode.md
 Models/RunTemplate.md
+Models/RunTemplateCreateRequest.md
 Models/RunTemplateParameter.md
 Models/RunTemplateParameterCreateRequest.md
 Models/RunTemplateParameterGroup.md
@@ -58,6 +59,7 @@ Models/RunTemplateParameterGroupUpdateRequest.md
 Models/RunTemplateParameterUpdateRequest.md
 Models/RunTemplateParameterValue.md
 Models/RunTemplateResourceSizing.md
+Models/RunTemplateUpdateRequest.md
 Models/Runner.md
 Models/RunnerAccessControl.md
 Models/RunnerCreateRequest.md

--- a/doc/Apis/SolutionApi.md
+++ b/doc/Apis/SolutionApi.md
@@ -8,17 +8,19 @@ All URIs are relative to *http://localhost*
 | [**createSolutionAccessControl**](SolutionApi.md#createSolutionAccessControl) | **POST** /organizations/{organization_id}/solutions/{solution_id}/security/access | Create solution access control |
 | [**createSolutionParameter**](SolutionApi.md#createSolutionParameter) | **POST** /organizations/{organization_id}/solutions/{solution_id}/parameters | Create solution parameter for a solution |
 | [**createSolutionParameterGroup**](SolutionApi.md#createSolutionParameterGroup) | **POST** /organizations/{organization_id}/solutions/{solution_id}/parameterGroups | Create a solution parameter group |
+| [**createSolutionRunTemplate**](SolutionApi.md#createSolutionRunTemplate) | **POST** /organizations/{organization_id}/solutions/{solution_id}/runTemplates | Create a solution run template |
 | [**deleteSolution**](SolutionApi.md#deleteSolution) | **DELETE** /organizations/{organization_id}/solutions/{solution_id} | Delete a solution |
 | [**deleteSolutionAccessControl**](SolutionApi.md#deleteSolutionAccessControl) | **DELETE** /organizations/{organization_id}/solutions/{solution_id}/security/access/{identity_id} | Delete solution access control |
 | [**deleteSolutionParameter**](SolutionApi.md#deleteSolutionParameter) | **DELETE** /organizations/{organization_id}/solutions/{solution_id}/parameters/{parameter_id} | Delete specific parameter from the solution |
 | [**deleteSolutionParameterGroup**](SolutionApi.md#deleteSolutionParameterGroup) | **DELETE** /organizations/{organization_id}/solutions/{solution_id}/parameterGroups/{parameter_group_id} | Delete a parameter group from the solution |
 | [**deleteSolutionRunTemplate**](SolutionApi.md#deleteSolutionRunTemplate) | **DELETE** /organizations/{organization_id}/solutions/{solution_id}/runTemplates/{run_template_id} | Delete a specific run template |
-| [**deleteSolutionRunTemplates**](SolutionApi.md#deleteSolutionRunTemplates) | **DELETE** /organizations/{organization_id}/solutions/{solution_id}/runTemplates | Delete all run templates from the solution |
+| [**getRunTemplate**](SolutionApi.md#getRunTemplate) | **GET** /organizations/{organization_id}/solutions/{solution_id}/runTemplates/{run_template_id} | Retrieve a solution run templates |
 | [**getSolution**](SolutionApi.md#getSolution) | **GET** /organizations/{organization_id}/solutions/{solution_id} | Get the details of a solution |
 | [**getSolutionAccessControl**](SolutionApi.md#getSolutionAccessControl) | **GET** /organizations/{organization_id}/solutions/{solution_id}/security/access/{identity_id} | Get solution access control |
 | [**getSolutionParameter**](SolutionApi.md#getSolutionParameter) | **GET** /organizations/{organization_id}/solutions/{solution_id}/parameters/{parameter_id} | Get the details of a solution parameter |
 | [**getSolutionParameterGroup**](SolutionApi.md#getSolutionParameterGroup) | **GET** /organizations/{organization_id}/solutions/{solution_id}/parameterGroups/{parameter_group_id} | Get details of a solution parameter group |
 | [**getSolutionSecurity**](SolutionApi.md#getSolutionSecurity) | **GET** /organizations/{organization_id}/solutions/{solution_id}/security | Get solution security information |
+| [**listRunTemplates**](SolutionApi.md#listRunTemplates) | **GET** /organizations/{organization_id}/solutions/{solution_id}/runTemplates | List all solution run templates |
 | [**listSolutionParameterGroups**](SolutionApi.md#listSolutionParameterGroups) | **GET** /organizations/{organization_id}/solutions/{solution_id}/parameterGroups | List all solution parameter groups |
 | [**listSolutionParameters**](SolutionApi.md#listSolutionParameters) | **GET** /organizations/{organization_id}/solutions/{solution_id}/parameters | List all solution parameters |
 | [**listSolutionSecurityUsers**](SolutionApi.md#listSolutionSecurityUsers) | **GET** /organizations/{organization_id}/solutions/{solution_id}/security/users | List solution security users |
@@ -29,7 +31,6 @@ All URIs are relative to *http://localhost*
 | [**updateSolutionParameter**](SolutionApi.md#updateSolutionParameter) | **PATCH** /organizations/{organization_id}/solutions/{solution_id}/parameters/{parameter_id} | Update solution parameter |
 | [**updateSolutionParameterGroup**](SolutionApi.md#updateSolutionParameterGroup) | **PATCH** /organizations/{organization_id}/solutions/{solution_id}/parameterGroups/{parameter_group_id} | Update a solution parameter group |
 | [**updateSolutionRunTemplate**](SolutionApi.md#updateSolutionRunTemplate) | **PATCH** /organizations/{organization_id}/solutions/{solution_id}/runTemplates/{run_template_id} | Update a specific run template |
-| [**updateSolutionRunTemplates**](SolutionApi.md#updateSolutionRunTemplates) | **PATCH** /organizations/{organization_id}/solutions/{solution_id}/runTemplates | Update solution run templates |
 
 
 <a name="createSolution"></a>
@@ -129,6 +130,33 @@ Create a solution parameter group
 ### Return type
 
 [**RunTemplateParameterGroup**](../Models/RunTemplateParameterGroup.md)
+
+### Authorization
+
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
+
+### HTTP request headers
+
+- **Content-Type**: application/json, application/yaml
+- **Accept**: application/json, application/yaml
+
+<a name="createSolutionRunTemplate"></a>
+# **createSolutionRunTemplate**
+> RunTemplate createSolutionRunTemplate(organization\_id, solution\_id, RunTemplateCreateRequest)
+
+Create a solution run template
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **organization\_id** | **String**| the Organization identifier | [default to null] |
+| **solution\_id** | **String**| the Solution identifier | [default to null] |
+| **RunTemplateCreateRequest** | [**RunTemplateCreateRequest**](../Models/RunTemplateCreateRequest.md)| Run template to create | |
+
+### Return type
+
+[**RunTemplate**](../Models/RunTemplate.md)
 
 ### Authorization
 
@@ -273,11 +301,11 @@ null (empty response body)
 - **Content-Type**: Not defined
 - **Accept**: Not defined
 
-<a name="deleteSolutionRunTemplates"></a>
-# **deleteSolutionRunTemplates**
-> deleteSolutionRunTemplates(organization\_id, solution\_id)
+<a name="getRunTemplate"></a>
+# **getRunTemplate**
+> RunTemplate getRunTemplate(organization\_id, solution\_id, run\_template\_id)
 
-Delete all run templates from the solution
+Retrieve a solution run templates
 
 ### Parameters
 
@@ -285,10 +313,11 @@ Delete all run templates from the solution
 |------------- | ------------- | ------------- | -------------|
 | **organization\_id** | **String**| the Organization identifier | [default to null] |
 | **solution\_id** | **String**| the Solution identifier | [default to null] |
+| **run\_template\_id** | **String**| the Run Template identifier | [default to null] |
 
 ### Return type
 
-null (empty response body)
+[**RunTemplate**](../Models/RunTemplate.md)
 
 ### Authorization
 
@@ -297,7 +326,7 @@ null (empty response body)
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: Not defined
+- **Accept**: application/json, application/yaml
 
 <a name="getSolution"></a>
 # **getSolution**
@@ -422,6 +451,32 @@ Get solution security information
 ### Return type
 
 [**SolutionSecurity**](../Models/SolutionSecurity.md)
+
+### Authorization
+
+[oAuth2AuthCode](../README.md#oAuth2AuthCode)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json, application/yaml
+
+<a name="listRunTemplates"></a>
+# **listRunTemplates**
+> List listRunTemplates(organization\_id, solution\_id)
+
+List all solution run templates
+
+### Parameters
+
+|Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **organization\_id** | **String**| the Organization identifier | [default to null] |
+| **solution\_id** | **String**| the Solution identifier | [default to null] |
+
+### Return type
+
+[**List**](../Models/RunTemplate.md)
 
 ### Authorization
 
@@ -677,7 +732,7 @@ Update a solution parameter group
 
 <a name="updateSolutionRunTemplate"></a>
 # **updateSolutionRunTemplate**
-> List updateSolutionRunTemplate(organization\_id, solution\_id, run\_template\_id, RunTemplate)
+> RunTemplate updateSolutionRunTemplate(organization\_id, solution\_id, run\_template\_id, RunTemplateUpdateRequest)
 
 Update a specific run template
 
@@ -688,38 +743,11 @@ Update a specific run template
 | **organization\_id** | **String**| the Organization identifier | [default to null] |
 | **solution\_id** | **String**| the Solution identifier | [default to null] |
 | **run\_template\_id** | **String**| the Run Template identifier | [default to null] |
-| **RunTemplate** | [**RunTemplate**](../Models/RunTemplate.md)| Run template updates | |
+| **RunTemplateUpdateRequest** | [**RunTemplateUpdateRequest**](../Models/RunTemplateUpdateRequest.md)| Run template updates | |
 
 ### Return type
 
-[**List**](../Models/RunTemplate.md)
-
-### Authorization
-
-[oAuth2AuthCode](../README.md#oAuth2AuthCode)
-
-### HTTP request headers
-
-- **Content-Type**: application/json, application/yaml
-- **Accept**: application/json, application/yaml
-
-<a name="updateSolutionRunTemplates"></a>
-# **updateSolutionRunTemplates**
-> List updateSolutionRunTemplates(organization\_id, solution\_id, RunTemplate)
-
-Update solution run templates
-
-### Parameters
-
-|Name | Type | Description  | Notes |
-|------------- | ------------- | ------------- | -------------|
-| **organization\_id** | **String**| the Organization identifier | [default to null] |
-| **solution\_id** | **String**| the Solution identifier | [default to null] |
-| **RunTemplate** | [**List**](../Models/RunTemplate.md)| Run templates to update | |
-
-### Return type
-
-[**List**](../Models/RunTemplate.md)
+[**RunTemplate**](../Models/RunTemplate.md)
 
 ### Authorization
 

--- a/doc/Models/RunTemplate.md
+++ b/doc/Models/RunTemplate.md
@@ -10,7 +10,7 @@
 | **tags** | **List** | The list of Run Template tags | [optional] [default to null] |
 | **computeSize** | **String** | The compute size needed for this Run Template | [optional] [default to null] |
 | **runSizing** | [**RunTemplateResourceSizing**](RunTemplateResourceSizing.md) |  | [optional] [default to null] |
-| **parameterGroups** | **List** | The ordered list of parameters groups for the Run Template | [optional] [default to null] |
+| **parameterGroups** | **List** | The ordered list of parameters groups for the Run Template | [default to null] |
 | **executionTimeout** | **Integer** | An optional duration in seconds in which a workflow is allowed to run | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/doc/Models/SolutionCreateRequest.md
+++ b/doc/Models/SolutionCreateRequest.md
@@ -13,7 +13,7 @@
 | **tags** | **List** | The list of tags | [optional] [default to null] |
 | **parameters** | [**List**](RunTemplateParameterCreateRequest.md) | The list of Run Template Parameters | [optional] [default to []] |
 | **parameterGroups** | [**List**](RunTemplateParameterGroupCreateRequest.md) | The list of parameters groups for the Run Templates | [optional] [default to []] |
-| **runTemplates** | [**List**](RunTemplate.md) | List of Run Templates | [optional] [default to []] |
+| **runTemplates** | [**List**](RunTemplateCreateRequest.md) | List of Run Templates | [optional] [default to []] |
 | **url** | **String** | An optional URL link to solution page | [optional] [default to null] |
 | **security** | [**SolutionSecurity**](SolutionSecurity.md) |  | [optional] [default to null] |
 

--- a/doc/Models/SolutionUpdateRequest.md
+++ b/doc/Models/SolutionUpdateRequest.md
@@ -12,8 +12,9 @@
 | **version** | **String** | The Solution version MAJOR.MINOR.PATCH. Must be aligned with an existing repository tag | [optional] [default to null] |
 | **url** | **String** | An optional URL link to solution page | [optional] [default to null] |
 | **tags** | **List** | The list of tags | [optional] [default to null] |
-| **parameters** | [**List**](RunTemplateParameterCreateRequest.md) | The list of Run Template Parameters | [optional] [default to []] |
-| **parameterGroups** | [**List**](RunTemplateParameterGroupCreateRequest.md) | The list of parameters groups for the Run Templates | [optional] [default to []] |
+| **parameters** | [**List**](RunTemplateParameterCreateRequest.md) | The list of Run Template Parameters | [optional] [default to null] |
+| **parameterGroups** | [**List**](RunTemplateParameterGroupCreateRequest.md) | The list of parameters groups for the Run Templates | [optional] [default to null] |
+| **runTemplates** | [**List**](RunTemplateCreateRequest.md) | List of Run Templates | [optional] [default to null] |
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -83,17 +83,19 @@ All URIs are relative to *http://localhost*
 *SolutionApi* | [**createSolutionAccessControl**](Apis/SolutionApi.md#createsolutionaccesscontrol) | **POST** /organizations/{organization_id}/solutions/{solution_id}/security/access | Create solution access control |
 *SolutionApi* | [**createSolutionParameter**](Apis/SolutionApi.md#createsolutionparameter) | **POST** /organizations/{organization_id}/solutions/{solution_id}/parameters | Create solution parameter for a solution |
 *SolutionApi* | [**createSolutionParameterGroup**](Apis/SolutionApi.md#createsolutionparametergroup) | **POST** /organizations/{organization_id}/solutions/{solution_id}/parameterGroups | Create a solution parameter group |
+*SolutionApi* | [**createSolutionRunTemplate**](Apis/SolutionApi.md#createsolutionruntemplate) | **POST** /organizations/{organization_id}/solutions/{solution_id}/runTemplates | Create a solution run template |
 *SolutionApi* | [**deleteSolution**](Apis/SolutionApi.md#deletesolution) | **DELETE** /organizations/{organization_id}/solutions/{solution_id} | Delete a solution |
 *SolutionApi* | [**deleteSolutionAccessControl**](Apis/SolutionApi.md#deletesolutionaccesscontrol) | **DELETE** /organizations/{organization_id}/solutions/{solution_id}/security/access/{identity_id} | Delete solution access control |
 *SolutionApi* | [**deleteSolutionParameter**](Apis/SolutionApi.md#deletesolutionparameter) | **DELETE** /organizations/{organization_id}/solutions/{solution_id}/parameters/{parameter_id} | Delete specific parameter from the solution |
 *SolutionApi* | [**deleteSolutionParameterGroup**](Apis/SolutionApi.md#deletesolutionparametergroup) | **DELETE** /organizations/{organization_id}/solutions/{solution_id}/parameterGroups/{parameter_group_id} | Delete a parameter group from the solution |
 *SolutionApi* | [**deleteSolutionRunTemplate**](Apis/SolutionApi.md#deletesolutionruntemplate) | **DELETE** /organizations/{organization_id}/solutions/{solution_id}/runTemplates/{run_template_id} | Delete a specific run template |
-*SolutionApi* | [**deleteSolutionRunTemplates**](Apis/SolutionApi.md#deletesolutionruntemplates) | **DELETE** /organizations/{organization_id}/solutions/{solution_id}/runTemplates | Delete all run templates from the solution |
+*SolutionApi* | [**getRunTemplate**](Apis/SolutionApi.md#getruntemplate) | **GET** /organizations/{organization_id}/solutions/{solution_id}/runTemplates/{run_template_id} | Retrieve a solution run templates |
 *SolutionApi* | [**getSolution**](Apis/SolutionApi.md#getsolution) | **GET** /organizations/{organization_id}/solutions/{solution_id} | Get the details of a solution |
 *SolutionApi* | [**getSolutionAccessControl**](Apis/SolutionApi.md#getsolutionaccesscontrol) | **GET** /organizations/{organization_id}/solutions/{solution_id}/security/access/{identity_id} | Get solution access control |
 *SolutionApi* | [**getSolutionParameter**](Apis/SolutionApi.md#getsolutionparameter) | **GET** /organizations/{organization_id}/solutions/{solution_id}/parameters/{parameter_id} | Get the details of a solution parameter |
 *SolutionApi* | [**getSolutionParameterGroup**](Apis/SolutionApi.md#getsolutionparametergroup) | **GET** /organizations/{organization_id}/solutions/{solution_id}/parameterGroups/{parameter_group_id} | Get details of a solution parameter group |
 *SolutionApi* | [**getSolutionSecurity**](Apis/SolutionApi.md#getsolutionsecurity) | **GET** /organizations/{organization_id}/solutions/{solution_id}/security | Get solution security information |
+*SolutionApi* | [**listRunTemplates**](Apis/SolutionApi.md#listruntemplates) | **GET** /organizations/{organization_id}/solutions/{solution_id}/runTemplates | List all solution run templates |
 *SolutionApi* | [**listSolutionParameterGroups**](Apis/SolutionApi.md#listsolutionparametergroups) | **GET** /organizations/{organization_id}/solutions/{solution_id}/parameterGroups | List all solution parameter groups |
 *SolutionApi* | [**listSolutionParameters**](Apis/SolutionApi.md#listsolutionparameters) | **GET** /organizations/{organization_id}/solutions/{solution_id}/parameters | List all solution parameters |
 *SolutionApi* | [**listSolutionSecurityUsers**](Apis/SolutionApi.md#listsolutionsecurityusers) | **GET** /organizations/{organization_id}/solutions/{solution_id}/security/users | List solution security users |
@@ -104,7 +106,6 @@ All URIs are relative to *http://localhost*
 *SolutionApi* | [**updateSolutionParameter**](Apis/SolutionApi.md#updatesolutionparameter) | **PATCH** /organizations/{organization_id}/solutions/{solution_id}/parameters/{parameter_id} | Update solution parameter |
 *SolutionApi* | [**updateSolutionParameterGroup**](Apis/SolutionApi.md#updatesolutionparametergroup) | **PATCH** /organizations/{organization_id}/solutions/{solution_id}/parameterGroups/{parameter_group_id} | Update a solution parameter group |
 *SolutionApi* | [**updateSolutionRunTemplate**](Apis/SolutionApi.md#updatesolutionruntemplate) | **PATCH** /organizations/{organization_id}/solutions/{solution_id}/runTemplates/{run_template_id} | Update a specific run template |
-*SolutionApi* | [**updateSolutionRunTemplates**](Apis/SolutionApi.md#updatesolutionruntemplates) | **PATCH** /organizations/{organization_id}/solutions/{solution_id}/runTemplates | Update solution run templates |
 | *WorkspaceApi* | [**createDatasetLink**](Apis/WorkspaceApi.md#createdatasetlink) | **POST** /organizations/{organization_id}/workspaces/{workspace_id}/link |  |
 *WorkspaceApi* | [**createWorkspace**](Apis/WorkspaceApi.md#createworkspace) | **POST** /organizations/{organization_id}/workspaces | Create a new workspace |
 *WorkspaceApi* | [**createWorkspaceAccessControl**](Apis/WorkspaceApi.md#createworkspaceaccesscontrol) | **POST** /organizations/{organization_id}/workspaces/{workspace_id}/security/access | Add a control access to the Workspace |
@@ -174,6 +175,7 @@ All URIs are relative to *http://localhost*
  - [RunStatus](./Models/RunStatus.md)
  - [RunStatusNode](./Models/RunStatusNode.md)
  - [RunTemplate](./Models/RunTemplate.md)
+ - [RunTemplateCreateRequest](./Models/RunTemplateCreateRequest.md)
  - [RunTemplateParameter](./Models/RunTemplateParameter.md)
  - [RunTemplateParameterCreateRequest](./Models/RunTemplateParameterCreateRequest.md)
  - [RunTemplateParameterGroup](./Models/RunTemplateParameterGroup.md)
@@ -182,6 +184,7 @@ All URIs are relative to *http://localhost*
  - [RunTemplateParameterUpdateRequest](./Models/RunTemplateParameterUpdateRequest.md)
  - [RunTemplateParameterValue](./Models/RunTemplateParameterValue.md)
  - [RunTemplateResourceSizing](./Models/RunTemplateResourceSizing.md)
+ - [RunTemplateUpdateRequest](./Models/RunTemplateUpdateRequest.md)
  - [Runner](./Models/Runner.md)
  - [RunnerAccessControl](./Models/RunnerAccessControl.md)
  - [RunnerCreateRequest](./Models/RunnerCreateRequest.md)

--- a/openapi/plantuml/schemas.plantuml
+++ b/openapi/plantuml/schemas.plantuml
@@ -310,6 +310,18 @@ entity RunTemplate {
     tags: List<String>
     computeSize: String
     runSizing: RunTemplateResourceSizing
+    * parameterGroups: List<String>
+    executionTimeout: Integer
+}
+
+entity RunTemplateCreateRequest {
+    * id: String
+    name: String
+    labels: Map
+    description: String
+    tags: List<String>
+    computeSize: String
+    runSizing: RunTemplateResourceSizing
     parameterGroups: List<String>
     executionTimeout: Integer
 }
@@ -387,6 +399,17 @@ entity RunTemplateParameterValue {
 entity RunTemplateResourceSizing {
     * requests: ResourceSizeInfo
     * limits: ResourceSizeInfo
+}
+
+entity RunTemplateUpdateRequest {
+    name: String
+    labels: Map
+    description: String
+    tags: List<String>
+    computeSize: String
+    runSizing: RunTemplateResourceSizing
+    parameterGroups: List<String>
+    executionTimeout: Integer
 }
 
 entity Runner {
@@ -513,7 +536,7 @@ entity SolutionCreateRequest {
     tags: List<String>
     parameters: List<RunTemplateParameterCreateRequest>
     parameterGroups: List<RunTemplateParameterGroupCreateRequest>
-    runTemplates: List<RunTemplate>
+    runTemplates: List<RunTemplateCreateRequest>
     url: String
     security: SolutionSecurity
 }
@@ -539,6 +562,7 @@ entity SolutionUpdateRequest {
     tags: List<String>
     parameters: List<RunTemplateParameterCreateRequest>
     parameterGroups: List<RunTemplateParameterGroupCreateRequest>
+    runTemplates: List<RunTemplateCreateRequest>
 }
 
 entity SourceInfo {
@@ -651,13 +675,15 @@ WorkspaceCreateRequest -- WorkspaceWebApp : webApp
 WorkspaceCreateRequest -- WorkspaceSecurity : security
 AboutInfo -- AboutInfoVersion : version
 ConnectorParameterGroup -- "0..*" ConnectorParameter : parameters
+RunTemplateUpdateRequest -- RunTemplateResourceSizing : runSizing
 RunContainer -- ContainerResourceSizing : runSizing
 SolutionCreateRequest -- "0..*" RunTemplateParameterCreateRequest : parameters
 SolutionCreateRequest -- "0..*" RunTemplateParameterGroupCreateRequest : parameterGroups
-SolutionCreateRequest -- "0..*" RunTemplate : runTemplates
+SolutionCreateRequest -- "0..*" RunTemplateCreateRequest : runTemplates
 SolutionCreateRequest -- SolutionSecurity : security
 SolutionUpdateRequest -- "0..*" RunTemplateParameterCreateRequest : parameters
 SolutionUpdateRequest -- "0..*" RunTemplateParameterGroupCreateRequest : parameterGroups
+SolutionUpdateRequest -- "0..*" RunTemplateCreateRequest : runTemplates
 OrganizationCreateRequest -- OrganizationSecurity : security
 Connector -- "0..*" ConnectorParameterGroup : parameterGroups
 Runner -- RunnerResourceSizing : runSizing
@@ -668,6 +694,7 @@ RunStatus -- "0..*" RunStatusNode : nodes
 FileUploadValidation -- "0..*" FileUploadMetadata : nodes
 FileUploadValidation -- "0..*" FileUploadMetadata : edges
 RunTemplate -- RunTemplateResourceSizing : runSizing
+RunTemplateCreateRequest -- RunTemplateResourceSizing : runSizing
 RunnerSecurity -- "0..*" RunnerAccessControl : accessControlList
 RunStatusNode -- RunResourceRequested : resourcesDuration
 WorkspaceUpdateRequest -- WorkspaceSolution : solution

--- a/run/src/integrationTest/kotlin/com/cosmotech/run/service/RunServiceIntegrationTest.kt
+++ b/run/src/integrationTest/kotlin/com/cosmotech/run/service/RunServiceIntegrationTest.kt
@@ -211,7 +211,7 @@ class RunServiceIntegrationTest : CsmRunTestBase() {
           name = "My solution",
           runTemplates =
               mutableListOf(
-                  RunTemplate(
+                  RunTemplateCreateRequest(
                       id = UUID.randomUUID().toString(),
                       name = "RunTemplate1",
                       description = "RunTemplate1 description")),

--- a/run/src/test/kotlin/com/cosmotech/run/ContainerFactoryTests.kt
+++ b/run/src/test/kotlin/com/cosmotech/run/ContainerFactoryTests.kt
@@ -244,7 +244,7 @@ class ContainerFactoryTests {
         id = CSM_RUN_TEMPLATE_ID,
         name = "Test Run",
         computeSize = "highcpupool",
-    )
+        parameterGroups = mutableListOf())
   }
 
   private fun getSolution(): Solution {

--- a/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceIntegrationTest.kt
+++ b/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceIntegrationTest.kt
@@ -1079,7 +1079,7 @@ class RunnerServiceIntegrationTest : CsmRedisTestBase() {
             ),
         runTemplates =
             mutableListOf(
-                RunTemplate(
+                RunTemplateCreateRequest(
                     id = "runTemplateId", parameterGroups = mutableListOf("testParameterGroups"))),
         csmSimulator = "simulator",
         repository = "repository",

--- a/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceRBACTest.kt
+++ b/runner/src/integrationTest/kotlin/com/cosmotech/runner/service/RunnerServiceRBACTest.kt
@@ -4448,7 +4448,7 @@ class RunnerServiceRBACTest : CsmRedisTestBase() {
       SolutionCreateRequest(
           key = UUID.randomUUID().toString(),
           name = "My solution",
-          runTemplates = mutableListOf(RunTemplate("runTemplateId")),
+          runTemplates = mutableListOf(RunTemplateCreateRequest("runTemplateId")),
           parameters = mutableListOf(RunTemplateParameterCreateRequest("parameter", "string")),
           repository = "repository",
           csmSimulator = "simulator",

--- a/solution/src/integrationTest/kotlin/com/cosmotech/solution/service/SolutionServiceIntegrationTest.kt
+++ b/solution/src/integrationTest/kotlin/com/cosmotech/solution/service/SolutionServiceIntegrationTest.kt
@@ -733,7 +733,8 @@ class SolutionServiceIntegrationTest : CsmRedisTestBase() {
               "WrongRunTemplateId",
               RunTemplateUpdateRequest())
         }
-    assertEquals("Run Template 'WrongRunTemplateId' *not* found", assertThrows.message)
+    assertEquals(
+        "Solution run template with id WrongRunTemplateId does not exist", assertThrows.message)
   }
 
   @Test
@@ -942,6 +943,7 @@ class SolutionServiceIntegrationTest : CsmRedisTestBase() {
             alwaysPull = false,
             repository = updatedRepository,
             csmSimulator = updatedCsmSimulator,
+            runTemplates = solutionRunTemplates,
             parameters =
                 mutableListOf(
                     RunTemplateParameterCreateRequest(
@@ -1024,6 +1026,7 @@ class SolutionServiceIntegrationTest : CsmRedisTestBase() {
             key = updatedKey,
             name = updatedName,
             description = updatedDescription,
+            runTemplates = solutionRunTemplates,
             tags = updatedTags,
             alwaysPull = false,
             repository = updatedRepository,
@@ -1122,6 +1125,157 @@ class SolutionServiceIntegrationTest : CsmRedisTestBase() {
         }
 
     assertEquals("One or several solution items have same id : parameters", exception.message)
+  }
+
+  @Test
+  fun `assert updateSolution with all information set and empty run template list in update`() {
+    val solutionKey = "key"
+    val solutionName = "name"
+    val solutionDescription = "description"
+    val solutionVersion = "1.0.0"
+    val solutionTags = mutableListOf("tag1", "tag2")
+    val solutionUrl = "url"
+    val solutionRunTemplates = mutableListOf(RunTemplateCreateRequest(id = "template"))
+    val solutionParameterGroups =
+        mutableListOf(RunTemplateParameterGroupCreateRequest(id = "group"))
+    val csmSimulator = "simulator"
+    val solutionRepository = "repository"
+
+    val solutionCreateRequest =
+        SolutionCreateRequest(
+            key = solutionKey,
+            name = solutionName,
+            description = solutionDescription,
+            version = solutionVersion,
+            tags = solutionTags,
+            repository = solutionRepository,
+            runTemplates = solutionRunTemplates,
+            parameterGroups = solutionParameterGroups,
+            parameters =
+                mutableListOf(
+                    RunTemplateParameterCreateRequest(id = "parameterName", varType = "string")),
+            security =
+                SolutionSecurity(
+                    default = ROLE_ADMIN,
+                    accessControlList =
+                        mutableListOf(SolutionAccessControl("user_id", ROLE_ADMIN))),
+            csmSimulator = csmSimulator,
+            url = solutionUrl,
+            alwaysPull = true,
+        )
+    solutionSaved = solutionApiService.createSolution(organizationSaved.id, solutionCreateRequest)
+
+    val updatedKey = "new key"
+    val updatedName = "new name"
+    val updatedDescription = "new description"
+    val updatedTags = mutableListOf("newTag1", "newTag2")
+    val updatedRepository = "new_repo"
+    val updatedCsmSimulator = "new_simulator"
+    val newUrl = "new_url"
+    val newVersion = "20.0.0"
+    val solutionUpdateRequest =
+        SolutionUpdateRequest(
+            key = updatedKey,
+            name = updatedName,
+            description = updatedDescription,
+            tags = updatedTags,
+            alwaysPull = false,
+            repository = updatedRepository,
+            csmSimulator = updatedCsmSimulator,
+            url = newUrl,
+            version = newVersion)
+
+    solutionSaved =
+        solutionApiService.updateSolution(
+            organizationSaved.id, solutionSaved.id, solutionUpdateRequest)
+
+    assertEquals(updatedKey, solutionSaved.key)
+    assertEquals(updatedName, solutionSaved.name)
+    assertEquals(updatedDescription, solutionSaved.description)
+    assertEquals(updatedTags, solutionSaved.tags)
+    assertEquals(updatedRepository, solutionSaved.repository)
+    assertEquals(updatedCsmSimulator, solutionSaved.csmSimulator)
+    assertEquals(0, solutionSaved.runTemplates.size)
+    assertEquals(newUrl, solutionSaved.url)
+    assertEquals(newVersion, solutionSaved.version)
+    assertEquals(0, solutionSaved.parameters.size)
+    assertEquals(ROLE_ADMIN, solutionSaved.security.default)
+    assertEquals(1, solutionSaved.security.accessControlList.size)
+    assertEquals("user_id", solutionSaved.security.accessControlList[0].id)
+    assertEquals(ROLE_ADMIN, solutionSaved.security.accessControlList[0].role)
+    assertFalse(solutionSaved.alwaysPull!!)
+  }
+
+  @Test
+  fun `assert updateSolution with all information set and duplicate id run templates list in update`() {
+    val solutionKey = "key"
+    val solutionName = "name"
+    val solutionDescription = "description"
+    val solutionVersion = "1.0.0"
+    val solutionTags = mutableListOf("tag1", "tag2")
+    val solutionUrl = "url"
+    val solutionRunTemplates = mutableListOf(RunTemplateCreateRequest(id = "template"))
+    val solutionParameterGroups =
+        mutableListOf(RunTemplateParameterGroupCreateRequest(id = "group"))
+    val csmSimulator = "simulator"
+    val solutionRepository = "repository"
+
+    val solutionCreateRequest =
+        SolutionCreateRequest(
+            key = solutionKey,
+            name = solutionName,
+            description = solutionDescription,
+            version = solutionVersion,
+            tags = solutionTags,
+            repository = solutionRepository,
+            runTemplates = solutionRunTemplates,
+            parameterGroups = solutionParameterGroups,
+            parameters =
+                mutableListOf(
+                    RunTemplateParameterCreateRequest(id = "parameterName", varType = "string")),
+            security =
+                SolutionSecurity(
+                    default = ROLE_ADMIN,
+                    accessControlList =
+                        mutableListOf(SolutionAccessControl("user_id", ROLE_ADMIN))),
+            csmSimulator = csmSimulator,
+            url = solutionUrl,
+            alwaysPull = true,
+        )
+    solutionSaved = solutionApiService.createSolution(organizationSaved.id, solutionCreateRequest)
+
+    val updatedKey = "new key"
+    val updatedName = "new name"
+    val updatedDescription = "new description"
+    val updatedTags = mutableListOf("newTag1", "newTag2")
+    val updatedRepository = "new_repo"
+    val updatedCsmSimulator = "new_simulator"
+    val newUrl = "new_url"
+    val newVersion = "20.0.0"
+    val solutionUpdateRequest =
+        SolutionUpdateRequest(
+            key = updatedKey,
+            name = updatedName,
+            description = updatedDescription,
+            tags = updatedTags,
+            alwaysPull = false,
+            repository = updatedRepository,
+            parameterGroups = solutionParameterGroups,
+            runTemplates =
+                mutableListOf(
+                    RunTemplateCreateRequest(id = "PaRaMeTeRnAmE"),
+                    RunTemplateCreateRequest(id = "pArAmEtErNaMe")),
+            csmSimulator = updatedCsmSimulator,
+            url = newUrl,
+            version = newVersion)
+
+    val exception =
+        assertThrows<IllegalArgumentException> {
+          solutionApiService.updateSolution(
+              organizationSaved.id, solutionSaved.id, solutionUpdateRequest)
+        }
+
+    assertEquals("One or several solution items have same id : runTemplates", exception.message)
   }
 
   @Test
@@ -1484,6 +1638,462 @@ class SolutionServiceIntegrationTest : CsmRedisTestBase() {
         }
 
     assertEquals("One or several solution items have same id : parameterGroups", exception.message)
+  }
+
+  @Test
+  fun `test empty list solution run templates`() {
+    val runTemplateList =
+        solutionApiService.listRunTemplates(organizationSaved.id, solutionSaved.id)
+    assertTrue(runTemplateList.isEmpty())
+  }
+
+  @Test
+  fun `test list run templates with non-existing solution`() {
+    val exception =
+        assertThrows<CsmResourceNotFoundException> {
+          solutionApiService.listRunTemplates(organizationSaved.id, "non-existing-solution-id")
+        }
+    assertEquals(
+        "Solution non-existing-solution-id not found in organization ${organizationSaved.id}",
+        exception.message)
+  }
+
+  @Test
+  fun `test list run templates`() {
+
+    val newSolutionWithRunTemplates =
+        makeSolution(
+            organizationSaved.id,
+            runTemplates =
+                mutableListOf(
+                    RunTemplateCreateRequest(
+                        id = "runTemplateId",
+                        description = "this_is_a_description",
+                        labels = mutableMapOf("fr" to "this_is_a_label"),
+                        name = "runTemplateName1",
+                        tags = mutableListOf("runTemplateTag1", "runTemplateTag2"),
+                        computeSize = "this_is_a_computeSize",
+                        runSizing =
+                            RunTemplateResourceSizing(
+                                requests = ResourceSizeInfo(cpu = "1Go", memory = "1Go"),
+                                limits = ResourceSizeInfo(cpu = "2Go", memory = "2Go"),
+                            ),
+                        parameterGroups = mutableListOf("parameterGroup1", "parameterGroup2"),
+                        executionTimeout = 10),
+                    RunTemplateCreateRequest(
+                        id = "runTemplateId2",
+                        description = "this_is_a_description2",
+                        labels = mutableMapOf("fr" to "this_is_a_label2"),
+                        name = "runTemplateName2",
+                        tags = mutableListOf("runTemplateTag3", "runTemplateTag4"),
+                        computeSize = "this_is_a_computeSize2",
+                        runSizing =
+                            RunTemplateResourceSizing(
+                                requests = ResourceSizeInfo(cpu = "3Go", memory = "3Go"),
+                                limits = ResourceSizeInfo(cpu = "4Go", memory = "4Go"),
+                            ),
+                        parameterGroups = mutableListOf("parameterGroup3", "parameterGroup4"),
+                        executionTimeout = 20)))
+
+    val newSolution =
+        solutionApiService.createSolution(organizationSaved.id, newSolutionWithRunTemplates)
+    val runTemplateList = solutionApiService.listRunTemplates(organizationSaved.id, newSolution.id)
+
+    assertEquals(2, runTemplateList.size)
+    val firstRunTemplate = runTemplateList[0]
+    assertEquals("runTemplateId", firstRunTemplate.id)
+    assertEquals("this_is_a_description", firstRunTemplate.description)
+    assertEquals(mutableMapOf("fr" to "this_is_a_label"), firstRunTemplate.labels)
+    assertEquals("runTemplateName1", firstRunTemplate.name)
+    assertEquals(mutableListOf("runTemplateTag1", "runTemplateTag2"), firstRunTemplate.tags)
+    assertEquals("this_is_a_computeSize", firstRunTemplate.computeSize)
+    assertEquals(
+        mutableListOf("parameterGroup1", "parameterGroup2"), firstRunTemplate.parameterGroups)
+    assertEquals(10, firstRunTemplate.executionTimeout!!)
+    assertEquals("1Go", firstRunTemplate.runSizing?.requests?.cpu)
+    assertEquals("1Go", firstRunTemplate.runSizing?.requests?.memory)
+    assertEquals("2Go", firstRunTemplate.runSizing?.limits?.cpu)
+    assertEquals("2Go", firstRunTemplate.runSizing?.limits?.memory)
+    val secondRunTemplate = runTemplateList[1]
+    assertEquals("runTemplateId2", secondRunTemplate.id)
+    assertEquals("this_is_a_description2", secondRunTemplate.description)
+    assertEquals(mutableMapOf("fr" to "this_is_a_label2"), secondRunTemplate.labels)
+    assertEquals("runTemplateName2", secondRunTemplate.name)
+    assertEquals(mutableListOf("runTemplateTag3", "runTemplateTag4"), secondRunTemplate.tags)
+    assertEquals("this_is_a_computeSize2", secondRunTemplate.computeSize)
+    assertEquals(
+        mutableListOf("parameterGroup3", "parameterGroup4"), secondRunTemplate.parameterGroups)
+    assertEquals(20, secondRunTemplate.executionTimeout!!)
+    assertEquals("3Go", secondRunTemplate.runSizing?.requests?.cpu)
+    assertEquals("3Go", secondRunTemplate.runSizing?.requests?.memory)
+    assertEquals("4Go", secondRunTemplate.runSizing?.limits?.cpu)
+    assertEquals("4Go", secondRunTemplate.runSizing?.limits?.memory)
+  }
+
+  @Test
+  fun `test get solution run template`() {
+    val newSolutionWithRunTemplates =
+        makeSolution(
+            organizationSaved.id,
+            runTemplates =
+                mutableListOf(
+                    RunTemplateCreateRequest(
+                        id = "runTemplateId",
+                        description = "this_is_a_description",
+                        labels = mutableMapOf("fr" to "this_is_a_label"),
+                        name = "runTemplateName1",
+                        tags = mutableListOf("runTemplateTag1", "runTemplateTag2"),
+                        computeSize = "this_is_a_computeSize",
+                        runSizing =
+                            RunTemplateResourceSizing(
+                                requests = ResourceSizeInfo(cpu = "1Go", memory = "1Go"),
+                                limits = ResourceSizeInfo(cpu = "2Go", memory = "2Go"),
+                            ),
+                        parameterGroups = mutableListOf("parameterGroup1", "parameterGroup2"),
+                        executionTimeout = 10),
+                    RunTemplateCreateRequest(
+                        id = "runTemplateId2",
+                        description = "this_is_a_description2",
+                        labels = mutableMapOf("fr" to "this_is_a_label2"),
+                        name = "runTemplateName2",
+                        tags = mutableListOf("runTemplateTag3", "runTemplateTag4"),
+                        computeSize = "this_is_a_computeSize2",
+                        runSizing =
+                            RunTemplateResourceSizing(
+                                requests = ResourceSizeInfo(cpu = "3Go", memory = "3Go"),
+                                limits = ResourceSizeInfo(cpu = "4Go", memory = "4Go"),
+                            ),
+                        parameterGroups = mutableListOf("parameterGroup3", "parameterGroup4"),
+                        executionTimeout = 20)))
+
+    val newSolution =
+        solutionApiService.createSolution(organizationSaved.id, newSolutionWithRunTemplates)
+
+    val runTemplate =
+        solutionApiService.getRunTemplate(
+            organizationSaved.id, newSolution.id, newSolution.runTemplates[0].id)
+
+    assertNotNull(runTemplate)
+    assertEquals("runTemplateId", runTemplate.id)
+    assertEquals("this_is_a_description", runTemplate.description)
+    assertEquals(mutableMapOf("fr" to "this_is_a_label"), runTemplate.labels)
+    assertEquals("runTemplateName1", runTemplate.name)
+    assertEquals(mutableListOf("runTemplateTag1", "runTemplateTag2"), runTemplate.tags)
+    assertEquals("this_is_a_computeSize", runTemplate.computeSize)
+    assertEquals(mutableListOf("parameterGroup1", "parameterGroup2"), runTemplate.parameterGroups)
+    assertEquals(10, runTemplate.executionTimeout!!)
+    assertEquals("1Go", runTemplate.runSizing?.requests?.cpu)
+    assertEquals("1Go", runTemplate.runSizing?.requests?.memory)
+    assertEquals("2Go", runTemplate.runSizing?.limits?.cpu)
+    assertEquals("2Go", runTemplate.runSizing?.limits?.memory)
+  }
+
+  @Test
+  fun `test get solution run template with non-existing run template id`() {
+    val exception =
+        assertThrows<CsmResourceNotFoundException> {
+          solutionApiService.getRunTemplate(
+              organizationSaved.id, solutionSaved.id, "non-existing-solution-run-template-id")
+        }
+    assertEquals(
+        "Solution run template with id non-existing-solution-run-template-id does not exist",
+        exception.message)
+  }
+
+  @Test
+  fun `test update solution run template`() {
+    val newSolutionWithRunTemplates =
+        makeSolution(
+            organizationSaved.id,
+            runTemplates =
+                mutableListOf(
+                    RunTemplateCreateRequest(
+                        id = "runTemplateId",
+                        description = "this_is_a_description",
+                        labels = mutableMapOf("fr" to "this_is_a_label"),
+                        name = "runTemplateName1",
+                        tags = mutableListOf("runTemplateTag1", "runTemplateTag2"),
+                        computeSize = "this_is_a_computeSize",
+                        runSizing =
+                            RunTemplateResourceSizing(
+                                requests = ResourceSizeInfo(cpu = "1Go", memory = "1Go"),
+                                limits = ResourceSizeInfo(cpu = "2Go", memory = "2Go"),
+                            ),
+                        parameterGroups = mutableListOf("parameterGroup1", "parameterGroup2"),
+                        executionTimeout = 10),
+                    RunTemplateCreateRequest(
+                        id = "runTemplateId2",
+                        description = "this_is_a_description2",
+                        labels = mutableMapOf("fr" to "this_is_a_label2"),
+                        name = "runTemplateName2",
+                        tags = mutableListOf("runTemplateTag3", "runTemplateTag4"),
+                        computeSize = "this_is_a_computeSize2",
+                        runSizing =
+                            RunTemplateResourceSizing(
+                                requests = ResourceSizeInfo(cpu = "3Go", memory = "3Go"),
+                                limits = ResourceSizeInfo(cpu = "4Go", memory = "4Go"),
+                            ),
+                        parameterGroups = mutableListOf("parameterGroup3", "parameterGroup4"),
+                        executionTimeout = 20)))
+
+    val newSolution =
+        solutionApiService.createSolution(organizationSaved.id, newSolutionWithRunTemplates)
+
+    val runTemplateId = newSolution.runTemplates[0].id
+    val runTemplate =
+        solutionApiService.updateSolutionRunTemplate(
+            organizationSaved.id,
+            newSolution.id,
+            runTemplateId,
+            RunTemplateUpdateRequest(
+                description = "this_is_a_description3",
+                labels = mutableMapOf("fr" to "this_is_a_label3"),
+                name = "runTemplateName3",
+                tags = mutableListOf("runTemplateTag5"),
+                computeSize = "this_is_a_computeSize3",
+                runSizing =
+                    RunTemplateResourceSizing(
+                        requests = ResourceSizeInfo(cpu = "1Go", memory = "1Go"),
+                        limits = ResourceSizeInfo(cpu = "1Go", memory = "1Go"),
+                    ),
+                parameterGroups = mutableListOf("parameterGroup5"),
+                executionTimeout = 5))
+    assertNotNull(runTemplate)
+    assertEquals("runTemplateId", runTemplate.id)
+    assertEquals("this_is_a_description3", runTemplate.description)
+    assertEquals(mutableMapOf("fr" to "this_is_a_label3"), runTemplate.labels)
+    assertEquals("runTemplateName3", runTemplate.name)
+    assertEquals(mutableListOf("runTemplateTag5"), runTemplate.tags)
+    assertEquals("this_is_a_computeSize3", runTemplate.computeSize)
+    assertEquals(mutableListOf("parameterGroup5"), runTemplate.parameterGroups)
+    assertEquals(5, runTemplate.executionTimeout!!)
+    assertEquals("1Go", runTemplate.runSizing?.requests?.cpu)
+    assertEquals("1Go", runTemplate.runSizing?.requests?.memory)
+    assertEquals("1Go", runTemplate.runSizing?.limits?.cpu)
+    assertEquals("1Go", runTemplate.runSizing?.limits?.memory)
+  }
+
+  @Test
+  fun `test update run template with non-existing run template id`() {
+    val exception =
+        assertThrows<CsmResourceNotFoundException> {
+          solutionApiService.updateSolutionRunTemplate(
+              organizationSaved.id,
+              solutionSaved.id,
+              "non-existing-solution-run-template-id",
+              RunTemplateUpdateRequest())
+        }
+    assertEquals(
+        "Solution run template with id non-existing-solution-run-template-id does not exist",
+        exception.message)
+  }
+
+  @Test
+  fun `test delete solution run template`() {
+
+    val newSolutionWithRunTemplates =
+        makeSolution(
+            organizationSaved.id,
+            runTemplates =
+                mutableListOf(
+                    RunTemplateCreateRequest(
+                        id = "runTemplateId",
+                        description = "this_is_a_description",
+                        labels = mutableMapOf("fr" to "this_is_a_label"),
+                        name = "runTemplateName1",
+                        tags = mutableListOf("runTemplateTag1", "runTemplateTag2"),
+                        computeSize = "this_is_a_computeSize",
+                        runSizing =
+                            RunTemplateResourceSizing(
+                                requests = ResourceSizeInfo(cpu = "1Go", memory = "1Go"),
+                                limits = ResourceSizeInfo(cpu = "2Go", memory = "2Go"),
+                            ),
+                        parameterGroups = mutableListOf("parameterGroup1", "parameterGroup2"),
+                        executionTimeout = 10),
+                    RunTemplateCreateRequest(
+                        id = "runTemplateId2",
+                        description = "this_is_a_description2",
+                        labels = mutableMapOf("fr" to "this_is_a_label2"),
+                        name = "runTemplateName2",
+                        tags = mutableListOf("runTemplateTag3", "runTemplateTag4"),
+                        computeSize = "this_is_a_computeSize2",
+                        runSizing =
+                            RunTemplateResourceSizing(
+                                requests = ResourceSizeInfo(cpu = "3Go", memory = "3Go"),
+                                limits = ResourceSizeInfo(cpu = "4Go", memory = "4Go"),
+                            ),
+                        parameterGroups = mutableListOf("parameterGroup3", "parameterGroup4"),
+                        executionTimeout = 20)))
+
+    val newSolution =
+        solutionApiService.createSolution(organizationSaved.id, newSolutionWithRunTemplates)
+
+    var listRunTemplates = solutionApiService.listRunTemplates(organizationSaved.id, newSolution.id)
+
+    val runTemplateIdToDelete = listRunTemplates[0].id
+    val runTemplateIdToKeep = listRunTemplates[1].id
+    solutionApiService.deleteSolutionRunTemplate(
+        organizationSaved.id, newSolution.id, runTemplateIdToDelete)
+
+    listRunTemplates = solutionApiService.listRunTemplates(organizationSaved.id, newSolution.id)
+
+    assertNotNull(listRunTemplates)
+    assertEquals(1, listRunTemplates.size)
+    assertEquals(runTemplateIdToKeep, listRunTemplates[0].id)
+  }
+
+  @Test
+  fun `test delete solution run template with non-existing run template id`() {
+    val exception =
+        assertThrows<CsmResourceNotFoundException> {
+          solutionApiService.deleteSolutionRunTemplate(
+              organizationSaved.id, solutionSaved.id, "non-existing-solution-run-template-id")
+        }
+    assertEquals(
+        "Solution run template with id non-existing-solution-run-template-id does not exist",
+        exception.message)
+  }
+
+  @Test
+  fun `test create solution run template with non-existing solution id`() {
+    val exception =
+        assertThrows<CsmResourceNotFoundException> {
+          solutionApiService.createSolutionRunTemplate(
+              organizationSaved.id,
+              "non-existing-solution-id",
+              RunTemplateCreateRequest(id = "my_run_template_id"))
+        }
+    assertEquals(
+        "Solution non-existing-solution-id not found in organization ${organizationSaved.id}",
+        exception.message)
+  }
+
+  @Test
+  fun `test create solution run template`() {
+    val newSolutionWithoutRunTemplates = makeSolution(organizationSaved.id)
+
+    val newSolutionWithEmptyRunTemplates =
+        solutionApiService.createSolution(organizationSaved.id, newSolutionWithoutRunTemplates)
+
+    assertTrue(newSolutionWithEmptyRunTemplates.parameterGroups.isEmpty())
+
+    val runTemplateCreateRequest =
+        RunTemplateCreateRequest(
+            id = "runTemplateId",
+            description = "this_is_a_description",
+            labels = mutableMapOf("fr" to "this_is_a_label"),
+            name = "runTemplateName1",
+            tags = mutableListOf("runTemplateTag1", "runTemplateTag2"),
+            computeSize = "this_is_a_computeSize",
+            runSizing =
+                RunTemplateResourceSizing(
+                    requests = ResourceSizeInfo(cpu = "1Go", memory = "1Go"),
+                    limits = ResourceSizeInfo(cpu = "2Go", memory = "2Go"),
+                ),
+            parameterGroups = mutableListOf("parameterGroup1", "parameterGroup2"),
+            executionTimeout = 10)
+
+    solutionApiService.createSolutionRunTemplate(
+        organizationSaved.id, newSolutionWithEmptyRunTemplates.id, runTemplateCreateRequest)
+
+    val newSolutionWithNewRunTemplate =
+        solutionApiService.getSolution(organizationSaved.id, newSolutionWithEmptyRunTemplates.id)
+
+    assertFalse(newSolutionWithNewRunTemplate.runTemplates.isEmpty())
+    assertEquals(1, newSolutionWithNewRunTemplate.runTemplates.size)
+    val newRunTemplate = newSolutionWithNewRunTemplate.runTemplates[0]
+    assertEquals("runTemplateId", newRunTemplate.id)
+    assertEquals("this_is_a_description", newRunTemplate.description)
+    assertEquals(mutableMapOf("fr" to "this_is_a_label"), newRunTemplate.labels)
+    assertEquals("runTemplateName1", newRunTemplate.name)
+    assertEquals(mutableListOf("runTemplateTag1", "runTemplateTag2"), newRunTemplate.tags)
+    assertEquals("this_is_a_computeSize", newRunTemplate.computeSize)
+    assertEquals(
+        mutableListOf("parameterGroup1", "parameterGroup2"), newRunTemplate.parameterGroups)
+    assertEquals(10, newRunTemplate.executionTimeout!!)
+    assertEquals("1Go", newRunTemplate.runSizing?.requests?.cpu)
+    assertEquals("1Go", newRunTemplate.runSizing?.requests?.memory)
+    assertEquals("2Go", newRunTemplate.runSizing?.limits?.cpu)
+    assertEquals("2Go", newRunTemplate.runSizing?.limits?.memory)
+  }
+
+  @Test
+  fun `test create solution run template with already existing run template id`() {
+    val runTemplateCreateRequest =
+        RunTemplateCreateRequest(
+            id = "runTemplateId",
+            description = "this_is_a_description",
+            labels = mutableMapOf("fr" to "this_is_a_label"),
+            name = "runTemplateName1",
+            tags = mutableListOf("runTemplateTag1", "runTemplateTag2"),
+            computeSize = "this_is_a_computeSize",
+            runSizing =
+                RunTemplateResourceSizing(
+                    requests = ResourceSizeInfo(cpu = "1Go", memory = "1Go"),
+                    limits = ResourceSizeInfo(cpu = "2Go", memory = "2Go"),
+                ),
+            parameterGroups = mutableListOf("parameterGroup1", "parameterGroup2"),
+            executionTimeout = 10)
+
+    val newSolutionWithRunTemplate =
+        solutionApiService.createSolution(
+            organizationSaved.id,
+            makeSolution(runTemplates = mutableListOf(runTemplateCreateRequest)))
+
+    assertEquals(1, newSolutionWithRunTemplate.runTemplates.size)
+
+    val exception =
+        assertThrows<IllegalArgumentException> {
+          solutionApiService.createSolutionRunTemplate(
+              organizationSaved.id, newSolutionWithRunTemplate.id, runTemplateCreateRequest)
+        }
+
+    assertEquals("Run template with id 'runTemplateId' already exists", exception.message)
+  }
+
+  @Test
+  fun `test create solution with several run template with the same id `() {
+
+    val newSolutionWithRunTemplates =
+        makeSolution(
+            organizationSaved.id,
+            runTemplates =
+                mutableListOf(
+                    RunTemplateCreateRequest(
+                        id = "rUnTeMpLaTeId",
+                        description = "this_is_a_description",
+                        labels = mutableMapOf("fr" to "this_is_a_label"),
+                        name = "runTemplateName1",
+                        tags = mutableListOf("runTemplateTag1", "runTemplateTag2"),
+                        computeSize = "this_is_a_computeSize",
+                        runSizing =
+                            RunTemplateResourceSizing(
+                                requests = ResourceSizeInfo(cpu = "1Go", memory = "1Go"),
+                                limits = ResourceSizeInfo(cpu = "2Go", memory = "2Go"),
+                            ),
+                        parameterGroups = mutableListOf("parameterGroup1", "parameterGroup2"),
+                        executionTimeout = 10),
+                    RunTemplateCreateRequest(
+                        id = "RuNtEmPlAtEId",
+                        description = "this_is_a_description2",
+                        labels = mutableMapOf("fr" to "this_is_a_label2"),
+                        name = "runTemplateName2",
+                        tags = mutableListOf("runTemplateTag3", "runTemplateTag4"),
+                        computeSize = "this_is_a_computeSize2",
+                        runSizing =
+                            RunTemplateResourceSizing(
+                                requests = ResourceSizeInfo(cpu = "3Go", memory = "3Go"),
+                                limits = ResourceSizeInfo(cpu = "4Go", memory = "4Go"),
+                            ),
+                        parameterGroups = mutableListOf("parameterGroup3", "parameterGroup4"),
+                        executionTimeout = 20)))
+
+    val exception =
+        assertThrows<IllegalArgumentException> {
+          solutionApiService.createSolution(organizationSaved.id, newSolutionWithRunTemplates)
+        }
+
+    assertEquals("One or several solution items have same id : runTemplates", exception.message)
   }
 
   fun makeOrganizationCreateRequest(id: String = "organization_id"): OrganizationCreateRequest {

--- a/solution/src/integrationTest/kotlin/com/cosmotech/solution/service/SolutionServiceRBACTest.kt
+++ b/solution/src/integrationTest/kotlin/com/cosmotech/solution/service/SolutionServiceRBACTest.kt
@@ -845,7 +845,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
   fun `test Solution RBAC deleteSolutionRunTemplate`() =
       mapOf(
               ROLE_VIEWER to true,
-              ROLE_EDITOR to true,
+              ROLE_EDITOR to false,
               ROLE_USER to true,
               ROLE_NONE to true,
               ROLE_ADMIN to false,
@@ -869,7 +869,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
                           organizationSaved.id, solutionSaved.id, "runTemplate")
                     }
                 assertEquals(
-                    "RBAC ${solutionSaved.id} - User does not have permission $PERMISSION_DELETE",
+                    "RBAC ${solutionSaved.id} - User does not have permission $PERMISSION_WRITE",
                     exception.message)
               } else {
                 assertDoesNotThrow {
@@ -1126,7 +1126,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
               ROLE_ADMIN to false,
           )
           .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplates : $role") {
+            DynamicTest.dynamicTest("Test Organization RBAC listSolutionParameters : $role") {
               every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
 
               val organization =
@@ -1164,7 +1164,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
               ROLE_ADMIN to false,
           )
           .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplates : $role") {
+            DynamicTest.dynamicTest("Test Organization RBAC getSolutionParameter : $role") {
               every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
 
               val organization =
@@ -1203,7 +1203,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
               ROLE_ADMIN to false,
           )
           .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplates : $role") {
+            DynamicTest.dynamicTest("Test Organization RBAC createSolutionParameter : $role") {
               every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
 
               val organization =
@@ -1245,7 +1245,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
               ROLE_ADMIN to false,
           )
           .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplates : $role") {
+            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionParameter : $role") {
               every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
 
               val organization =
@@ -1286,7 +1286,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
               ROLE_ADMIN to false,
           )
           .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplates : $role") {
+            DynamicTest.dynamicTest("Test Organization RBAC deleteSolutionParameter : $role") {
               every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
 
               val organization =
@@ -1325,7 +1325,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
               ROLE_ADMIN to false,
           )
           .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplates : $role") {
+            DynamicTest.dynamicTest("Test Organization RBAC listSolutionParameterGroups : $role") {
               every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
 
               val organization =
@@ -1364,7 +1364,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
               ROLE_ADMIN to false,
           )
           .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplates : $role") {
+            DynamicTest.dynamicTest("Test Organization RBAC getSolutionParameterGroup : $role") {
               every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
 
               val organization =
@@ -1403,7 +1403,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
               ROLE_ADMIN to false,
           )
           .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplates : $role") {
+            DynamicTest.dynamicTest("Test Organization RBAC createSolutionParameterGroup : $role") {
               every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
 
               val organization =
@@ -1444,7 +1444,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
               ROLE_ADMIN to false,
           )
           .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplates : $role") {
+            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionParameterGroup : $role") {
               every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
 
               val organization =
@@ -1486,7 +1486,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
               ROLE_ADMIN to false,
           )
           .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplates : $role") {
+            DynamicTest.dynamicTest("Test Organization RBAC deleteSolutionParameterGroup : $role") {
               every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
 
               val organization =
@@ -1510,6 +1510,206 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
                 assertDoesNotThrow {
                   solutionApiService.deleteSolutionParameterGroup(
                       organizationSaved.id, solutionSaved.id, "group")
+                }
+              }
+            }
+          }
+
+  @TestFactory
+  fun `test RBAC list solution run templates`() =
+      mapOf(
+              ROLE_VIEWER to false,
+              ROLE_EDITOR to false,
+              ROLE_USER to false,
+              ROLE_NONE to true,
+              ROLE_ADMIN to false,
+          )
+          .map { (role, shouldThrow) ->
+            DynamicTest.dynamicTest("Test Organization RBAC listRunTemplates : $role") {
+              every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
+
+              val organization =
+                  makeOrganizationCreateRequest(id = TEST_USER_MAIL, role = ROLE_ADMIN)
+              organizationSaved = organizationApiService.createOrganization(organization)
+              val solution = makeSolutionWithRole(organizationSaved.id, TEST_USER_MAIL, role = role)
+              solutionSaved = solutionApiService.createSolution(organizationSaved.id, solution)
+
+              every { getCurrentAccountIdentifier(any()) } returns TEST_USER_MAIL
+
+              if (shouldThrow) {
+                val exception =
+                    assertThrows<CsmAccessForbiddenException> {
+                      solutionApiService.listRunTemplates(organizationSaved.id, solutionSaved.id)
+                    }
+                assertEquals(
+                    "RBAC ${solutionSaved.id} - User does not have permission $PERMISSION_READ",
+                    exception.message)
+              } else {
+                assertDoesNotThrow {
+                  solutionApiService.listRunTemplates(organizationSaved.id, solutionSaved.id)
+                }
+              }
+            }
+          }
+
+  @TestFactory
+  fun `test RBAC get solution run template`() =
+      mapOf(
+              ROLE_VIEWER to false,
+              ROLE_EDITOR to false,
+              ROLE_USER to false,
+              ROLE_NONE to true,
+              ROLE_ADMIN to false,
+          )
+          .map { (role, shouldThrow) ->
+            DynamicTest.dynamicTest("Test Organization RBAC getRunTemplate : $role") {
+              every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
+
+              val organization =
+                  makeOrganizationCreateRequest(id = TEST_USER_MAIL, role = ROLE_ADMIN)
+              organizationSaved = organizationApiService.createOrganization(organization)
+              val solution = makeSolutionWithRole(organizationSaved.id, TEST_USER_MAIL, role = role)
+              solutionSaved = solutionApiService.createSolution(organizationSaved.id, solution)
+
+              every { getCurrentAccountIdentifier(any()) } returns TEST_USER_MAIL
+
+              if (shouldThrow) {
+                val exception =
+                    assertThrows<CsmAccessForbiddenException> {
+                      solutionApiService.getRunTemplate(
+                          organizationSaved.id, solutionSaved.id, "runTemplate")
+                    }
+                assertEquals(
+                    "RBAC ${solutionSaved.id} - User does not have permission $PERMISSION_READ",
+                    exception.message)
+              } else {
+                assertDoesNotThrow {
+                  solutionApiService.getRunTemplate(
+                      organizationSaved.id, solutionSaved.id, "runTemplate")
+                }
+              }
+            }
+          }
+
+  @TestFactory
+  fun `test RBAC create solution run template`() =
+      mapOf(
+              ROLE_VIEWER to true,
+              ROLE_EDITOR to false,
+              ROLE_USER to true,
+              ROLE_NONE to true,
+              ROLE_ADMIN to false,
+          )
+          .map { (role, shouldThrow) ->
+            DynamicTest.dynamicTest("Test Organization RBAC createSolutionRunTemplate : $role") {
+              every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
+
+              val organization =
+                  makeOrganizationCreateRequest(id = TEST_USER_MAIL, role = ROLE_ADMIN)
+              organizationSaved = organizationApiService.createOrganization(organization)
+              val solution = makeSolutionWithRole(organizationSaved.id, TEST_USER_MAIL, role = role)
+              solutionSaved = solutionApiService.createSolution(organizationSaved.id, solution)
+
+              every { getCurrentAccountIdentifier(any()) } returns TEST_USER_MAIL
+
+              val runTemplateToCreate = RunTemplateCreateRequest(id = "group2")
+
+              if (shouldThrow) {
+                val exception =
+                    assertThrows<CsmAccessForbiddenException> {
+                      solutionApiService.createSolutionRunTemplate(
+                          organizationSaved.id, solutionSaved.id, runTemplateToCreate)
+                    }
+                assertEquals(
+                    "RBAC ${solutionSaved.id} - User does not have permission $PERMISSION_WRITE",
+                    exception.message)
+              } else {
+                assertDoesNotThrow {
+                  solutionApiService.createSolutionRunTemplate(
+                      organizationSaved.id, solutionSaved.id, runTemplateToCreate)
+                }
+              }
+            }
+          }
+
+  @TestFactory
+  fun `test RBAC update solution run template`() =
+      mapOf(
+              ROLE_VIEWER to true,
+              ROLE_EDITOR to false,
+              ROLE_USER to true,
+              ROLE_NONE to true,
+              ROLE_ADMIN to false,
+          )
+          .map { (role, shouldThrow) ->
+            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplate : $role") {
+              every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
+
+              val organization =
+                  makeOrganizationCreateRequest(id = TEST_USER_MAIL, role = ROLE_ADMIN)
+              organizationSaved = organizationApiService.createOrganization(organization)
+              val solution = makeSolutionWithRole(organizationSaved.id, TEST_USER_MAIL, role = role)
+              solutionSaved = solutionApiService.createSolution(organizationSaved.id, solution)
+
+              every { getCurrentAccountIdentifier(any()) } returns TEST_USER_MAIL
+
+              val runTemplateToUpdate = RunTemplateUpdateRequest(description = "description")
+
+              if (shouldThrow) {
+                val exception =
+                    assertThrows<CsmAccessForbiddenException> {
+                      solutionApiService.updateSolutionRunTemplate(
+                          organizationSaved.id,
+                          solutionSaved.id,
+                          "runTemplate",
+                          runTemplateToUpdate)
+                    }
+                assertEquals(
+                    "RBAC ${solutionSaved.id} - User does not have permission $PERMISSION_WRITE",
+                    exception.message)
+              } else {
+                assertDoesNotThrow {
+                  solutionApiService.updateSolutionRunTemplate(
+                      organizationSaved.id, solutionSaved.id, "runTemplate", runTemplateToUpdate)
+                }
+              }
+            }
+          }
+
+  @TestFactory
+  fun `test RBAC delete solution run template`() =
+      mapOf(
+              ROLE_VIEWER to true,
+              ROLE_EDITOR to false,
+              ROLE_USER to true,
+              ROLE_NONE to true,
+              ROLE_ADMIN to false,
+          )
+          .map { (role, shouldThrow) ->
+            DynamicTest.dynamicTest("Test Organization RBAC deleteSolutionRunTemplate : $role") {
+              every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
+
+              val organization =
+                  makeOrganizationCreateRequest(id = TEST_USER_MAIL, role = ROLE_ADMIN)
+              organizationSaved = organizationApiService.createOrganization(organization)
+              val solution = makeSolutionWithRole(organizationSaved.id, TEST_USER_MAIL, role = role)
+              solutionSaved = solutionApiService.createSolution(organizationSaved.id, solution)
+
+              every { getCurrentAccountIdentifier(any()) } returns TEST_USER_MAIL
+
+              if (shouldThrow) {
+                val exception =
+                    assertThrows<CsmAccessForbiddenException> {
+                      solutionApiService.deleteSolutionRunTemplate(
+                          organizationSaved.id, solutionSaved.id, "runTemplate")
+                    }
+                assertEquals(
+                    "RBAC ${solutionSaved.id} - User does not have permission $PERMISSION_WRITE",
+                    exception.message)
+              } else {
+                assertDoesNotThrow {
+                  solutionApiService.deleteSolutionRunTemplate(
+                      organizationSaved.id, solutionSaved.id, "runTemplate")
                 }
               }
             }

--- a/solution/src/integrationTest/kotlin/com/cosmotech/solution/service/SolutionServiceRBACTest.kt
+++ b/solution/src/integrationTest/kotlin/com/cosmotech/solution/service/SolutionServiceRBACTest.kt
@@ -804,166 +804,6 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
           }
 
   @TestFactory
-  fun `test Organization RBAC updateSolutionRunTemplates`() =
-      mapOf(
-              ROLE_VIEWER to false,
-              ROLE_EDITOR to false,
-              ROLE_USER to false,
-              ROLE_NONE to true,
-              ROLE_ADMIN to false,
-          )
-          .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplates : $role") {
-              every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
-
-              val organization = makeOrganizationCreateRequest(id = TEST_USER_MAIL, role = role)
-              organizationSaved = organizationApiService.createOrganization(organization)
-              val solution = makeSolutionWithRole(id = TEST_USER_MAIL, role = ROLE_ADMIN)
-              solutionSaved = solutionApiService.createSolution(organizationSaved.id, solution)
-
-              val runTemplate = RunTemplate("id")
-
-              every { getCurrentAccountIdentifier(any()) } returns TEST_USER_MAIL
-
-              if (shouldThrow) {
-                val exception =
-                    assertThrows<CsmAccessForbiddenException> {
-                      solutionApiService.updateSolutionRunTemplates(
-                          organizationSaved.id, solutionSaved.id, listOf(runTemplate))
-                    }
-                assertEquals(
-                    "RBAC ${organizationSaved.id} - User does not have permission $PERMISSION_READ",
-                    exception.message)
-              } else {
-                assertDoesNotThrow {
-                  solutionApiService.updateSolutionRunTemplates(
-                      organizationSaved.id, solutionSaved.id, listOf(runTemplate))
-                }
-              }
-            }
-          }
-
-  @TestFactory
-  fun `test Solution RBAC updateSolutionRunTemplates`() =
-      mapOf(
-              ROLE_VIEWER to true,
-              ROLE_EDITOR to false,
-              ROLE_USER to true,
-              ROLE_NONE to true,
-              ROLE_ADMIN to false,
-          )
-          .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Solution RBAC updateSolutionRunTemplates : $role") {
-              every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
-
-              val organization =
-                  makeOrganizationCreateRequest(id = TEST_USER_MAIL, role = ROLE_ADMIN)
-              organizationSaved = organizationApiService.createOrganization(organization)
-              val solution = makeSolutionWithRole(id = TEST_USER_MAIL, role = role)
-              solutionSaved = solutionApiService.createSolution(organizationSaved.id, solution)
-
-              val runTemplate = RunTemplate("id")
-
-              every { getCurrentAccountIdentifier(any()) } returns TEST_USER_MAIL
-
-              if (shouldThrow) {
-                val exception =
-                    assertThrows<CsmAccessForbiddenException> {
-                      solutionApiService.updateSolutionRunTemplates(
-                          organizationSaved.id, solutionSaved.id, listOf(runTemplate))
-                    }
-
-                assertEquals(
-                    "RBAC ${solutionSaved.id} - User does not have permission $PERMISSION_WRITE",
-                    exception.message)
-              } else {
-                assertDoesNotThrow {
-                  solutionApiService.updateSolutionRunTemplates(
-                      organizationSaved.id, solutionSaved.id, listOf(runTemplate))
-                }
-              }
-            }
-          }
-
-  @TestFactory
-  fun `test Organization RBAC deleteSolutionRunTemplates`() =
-      mapOf(
-              ROLE_VIEWER to false,
-              ROLE_EDITOR to false,
-              ROLE_USER to false,
-              ROLE_NONE to true,
-              ROLE_ADMIN to false,
-          )
-          .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Organization RBAC updateSolutionRunTemplates : $role") {
-              every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
-
-              val organization = makeOrganizationCreateRequest(id = TEST_USER_MAIL, role = role)
-              organizationSaved = organizationApiService.createOrganization(organization)
-              val solution = makeSolutionWithRole(id = TEST_USER_MAIL, role = ROLE_ADMIN)
-              solutionSaved = solutionApiService.createSolution(organizationSaved.id, solution)
-
-              every { getCurrentAccountIdentifier(any()) } returns TEST_USER_MAIL
-
-              if (shouldThrow) {
-                val exception =
-                    assertThrows<CsmAccessForbiddenException> {
-                      solutionApiService.deleteSolutionRunTemplates(
-                          organizationSaved.id, solutionSaved.id)
-                    }
-                assertEquals(
-                    "RBAC ${organizationSaved.id} - User does not have permission $PERMISSION_READ",
-                    exception.message)
-              } else {
-                assertDoesNotThrow {
-                  solutionApiService.deleteSolutionRunTemplates(
-                      organizationSaved.id, solutionSaved.id)
-                }
-              }
-            }
-          }
-
-  @TestFactory
-  fun `test Solution RBAC deleteSolutionRunTemplates`() =
-      mapOf(
-              ROLE_VIEWER to true,
-              ROLE_EDITOR to true,
-              ROLE_USER to true,
-              ROLE_NONE to true,
-              ROLE_ADMIN to false,
-          )
-          .map { (role, shouldThrow) ->
-            DynamicTest.dynamicTest("Test Solution RBAC updateSolutionRunTemplates : $role") {
-              every { getCurrentAccountIdentifier(any()) } returns CONNECTED_ADMIN_USER
-
-              val organization =
-                  makeOrganizationCreateRequest(id = TEST_USER_MAIL, role = ROLE_ADMIN)
-              organizationSaved = organizationApiService.createOrganization(organization)
-              val solution = makeSolutionWithRole(id = TEST_USER_MAIL, role = role)
-              solutionSaved = solutionApiService.createSolution(organizationSaved.id, solution)
-
-              every { getCurrentAccountIdentifier(any()) } returns TEST_USER_MAIL
-
-              if (shouldThrow) {
-                val exception =
-                    assertThrows<CsmAccessForbiddenException> {
-                      solutionApiService.deleteSolutionRunTemplates(
-                          organizationSaved.id, solutionSaved.id)
-                    }
-
-                assertEquals(
-                    "RBAC ${solutionSaved.id} - User does not have permission $PERMISSION_DELETE",
-                    exception.message)
-              } else {
-                assertDoesNotThrow {
-                  solutionApiService.deleteSolutionRunTemplates(
-                      organizationSaved.id, solutionSaved.id)
-                }
-              }
-            }
-          }
-
-  @TestFactory
   fun `test Organization RBAC deleteSolutionRunTemplate`() =
       mapOf(
               ROLE_VIEWER to false,
@@ -1058,7 +898,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
               val solution = makeSolutionWithRole(id = TEST_USER_MAIL, role = ROLE_ADMIN)
               solutionSaved = solutionApiService.createSolution(organizationSaved.id, solution)
 
-              val runTemplate = RunTemplate("runTemplate", "name")
+              val runTemplate = RunTemplateUpdateRequest(name = "name")
 
               every { getCurrentAccountIdentifier(any()) } returns TEST_USER_MAIL
 
@@ -1099,7 +939,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
               val solution = makeSolutionWithRole(id = TEST_USER_MAIL, role = role)
               solutionSaved = solutionApiService.createSolution(organizationSaved.id, solution)
 
-              val runTemplate = RunTemplate("runTemplate", "name")
+              val runTemplate = RunTemplateUpdateRequest(name = "name")
 
               every { getCurrentAccountIdentifier(any()) } returns TEST_USER_MAIL
 
@@ -1698,7 +1538,7 @@ class SolutionServiceRBACTest : CsmRedisTestBase() {
       SolutionCreateRequest(
           key = UUID.randomUUID().toString(),
           name = "My solution",
-          runTemplates = mutableListOf(RunTemplate("runTemplate")),
+          runTemplates = mutableListOf(RunTemplateCreateRequest(id = "runTemplate")),
           csmSimulator = "simulator",
           version = "1.0.0",
           repository = "repository",

--- a/solution/src/main/kotlin/com/cosmotech/solution/service/SolutionServiceImpl.kt
+++ b/solution/src/main/kotlin/com/cosmotech/solution/service/SolutionServiceImpl.kt
@@ -235,7 +235,7 @@ class SolutionServiceImpl(
       solutionId: String,
       runTemplateId: String
   ) {
-    val existingSolution = getVerifiedSolution(organizationId, solutionId, PERMISSION_DELETE)
+    val existingSolution = getVerifiedSolution(organizationId, solutionId, PERMISSION_WRITE)
 
     if (!existingSolution.runTemplates.removeIf { it.id == runTemplateId }) {
       throw CsmResourceNotFoundException("Run Template '$runTemplateId' *not* found")

--- a/solution/src/main/openapi/solution.yaml
+++ b/solution/src/main/openapi/solution.yaml
@@ -505,6 +505,11 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RunTemplate'
+            application/yaml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RunTemplate'
         "404":
           description: Solution not found or insufficient access rights
     post:
@@ -527,6 +532,9 @@ paths:
           description: Run template successfully created
           content:
             application/json:
+              schema:
+                $ref: '#/components/schemas/RunTemplate'
+            application/yaml:
               schema:
                 $ref: '#/components/schemas/RunTemplate'
         "400":
@@ -567,6 +575,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RunTemplate'
+            application/yaml:
+              schema:
+                $ref: '#/components/schemas/RunTemplate'
         "404":
           description: Solution not found or insufficient access rights
     patch:
@@ -589,6 +600,9 @@ paths:
           description: Run template successfully updated
           content:
             application/json:
+              schema:
+                $ref: '#/components/schemas/RunTemplate'
+            application/yaml:
               schema:
                 $ref: '#/components/schemas/RunTemplate'
         "400":

--- a/solution/src/main/openapi/solution.yaml
+++ b/solution/src/main/openapi/solution.yaml
@@ -491,59 +491,49 @@ paths:
         required: true
         schema:
           type: string
-    patch:
-      operationId: updateSolutionRunTemplates
+    get:
+      operationId: listRunTemplates
       tags:
         - solution
-      summary: Update solution run templates
-      requestBody:
-        description: Run templates to update
-        required: true
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: "#/components/schemas/RunTemplate"
-            examples:
-              RunTemplates:
-                $ref: '#/components/examples/RunTemplates'
-          application/yaml:
-            schema:
-              type: array
-              items:
-                $ref: "#/components/schemas/RunTemplate"
-            examples:
-              RunTemplates:
-                $ref: '#/components/examples/RunTemplates'
+      summary: List all solution run templates
       responses:
-        "201":
-          description: Run templates successfully updated
+        "200":
+          description: Run templates successfully listed
           content:
             application/json:
               schema:
                 type: array
                 items:
                   $ref: '#/components/schemas/RunTemplate'
-            application/yaml:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RunTemplate'
-        "400":
-          description: Bad request - Invalid run templates
         "404":
           description: Solution not found or insufficient access rights
-    delete:
-      operationId: deleteSolutionRunTemplates
+    post:
+      operationId: createSolutionRunTemplate
       tags:
         - solution
-      summary: Delete all run templates from the solution
+      summary: Create a solution run template
+      requestBody:
+        description: Run template to create
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RunTemplateCreateRequest"
+          application/yaml:
+            schema:
+              $ref: "#/components/schemas/RunTemplateCreateRequest"
       responses:
-        "204":
-          description: Run templates successfully deleted
+        "201":
+          description: Run template successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunTemplate'
+        "400":
+          description: Bad request - Invalid run template
         "404":
           description: Solution not found or insufficient access rights
+
 
   /organizations/{organization_id}/solutions/{solution_id}/runTemplates/{run_template_id}:
     parameters:
@@ -565,6 +555,20 @@ paths:
         required: true
         schema:
           type: string
+    get:
+      operationId: getRunTemplate
+      tags:
+        - solution
+      summary: Retrieve a solution run templates
+      responses:
+        "200":
+          description: Run template successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunTemplate'
+        "404":
+          description: Solution not found or insufficient access rights
     patch:
       operationId: updateSolutionRunTemplate
       tags:
@@ -576,30 +580,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/RunTemplate"
-            examples:
-              RunTemplate:
-                $ref: '#/components/examples/RunTemplate'
+              $ref: "#/components/schemas/RunTemplateUpdateRequest"
           application/yaml:
             schema:
-              $ref: "#/components/schemas/RunTemplate"
-            examples:
-              RunTemplate:
-                $ref: '#/components/examples/RunTemplate'
+              $ref: "#/components/schemas/RunTemplateUpdateRequest"
       responses:
         "200":
           description: Run template successfully updated
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RunTemplate'
-            application/yaml:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/RunTemplate'
+                $ref: '#/components/schemas/RunTemplate'
         "400":
           description: Bad request - Invalid run template updates
         "404":
@@ -1066,7 +1057,7 @@ components:
           default: []
           description: List of Run Templates
           items:
-            $ref: '#/components/schemas/RunTemplate'
+            $ref: '#/components/schemas/RunTemplateCreateRequest'
         url:
           type: string
           description: An optional URL link to solution page
@@ -1132,15 +1123,18 @@ components:
         parameters:
           type: array
           description: The list of Run Template Parameters
-          default: [ ]
           items:
             $ref: '#/components/schemas/RunTemplateParameterCreateRequest'
         parameterGroups:
           type: array
           description: The list of parameters groups for the Run Templates
-          default: []
           items:
             $ref: '#/components/schemas/RunTemplateParameterGroupCreateRequest'
+        runTemplates:
+          type: array
+          description: List of Run Templates
+          items:
+            $ref: '#/components/schemas/RunTemplateCreateRequest'
 
     # Security Objects
     SolutionSecurity:
@@ -1233,6 +1227,86 @@ components:
           description: An optional duration in seconds in which a workflow is allowed to run
       required:
         - id
+        - parameterGroups
+
+    RunTemplateCreateRequest:
+      type: object
+      description: A Solution Run Template Create Request
+      properties:
+        id:
+          type: string
+          description: The Solution Run Template id
+          minLength: 1
+          maxLength: 50
+          example: "template-123"
+        name:
+          type: string
+          description: The Run Template name
+          minLength: 1
+          maxLength: 50
+        labels:
+          $ref: '#/components/schemas/TranslatedLabels'
+        description:
+          type: string
+          description: The Run Template description
+        tags:
+          type: array
+          description: The list of Run Template tags
+          items:
+            type: string
+        computeSize:
+          type: string
+          description: The compute size needed for this Run Template
+        runSizing:
+          description: Definition of resources needed for the scenario run
+          $ref: "#/components/schemas/RunTemplateResourceSizing"
+        parameterGroups:
+          type: array
+          default: []
+          description: The ordered list of parameters groups for the Run Template
+          items:
+            type: string
+            description: A Run Template Group Parameter id
+        executionTimeout:
+          type: integer
+          description: An optional duration in seconds in which a workflow is allowed to run
+      required:
+        - id
+
+    RunTemplateUpdateRequest:
+      type: object
+      description: A Solution Run Template Create Request
+      properties:
+        name:
+          type: string
+          description: The Run Template name
+          minLength: 1
+          maxLength: 50
+        labels:
+          $ref: '#/components/schemas/TranslatedLabels'
+        description:
+          type: string
+          description: The Run Template description
+        tags:
+          type: array
+          description: The list of Run Template tags
+          items:
+            type: string
+        computeSize:
+          type: string
+          description: The compute size needed for this Run Template
+        runSizing:
+          description: Definition of resources needed for the scenario run
+          $ref: "#/components/schemas/RunTemplateResourceSizing"
+        parameterGroups:
+          type: array
+          description: The ordered list of parameters groups for the Run Template
+          items:
+            type: string
+            description: A Run Template Group Parameter id
+        executionTimeout:
+          type: integer
+          description: An optional duration in seconds in which a workflow is allowed to run
 
     RunTemplateResourceSizing:
       type: object

--- a/workspace/src/integrationTest/kotlin/com/cosmotech/workspace/service/WorkspaceServiceIntegrationTest.kt
+++ b/workspace/src/integrationTest/kotlin/com/cosmotech/workspace/service/WorkspaceServiceIntegrationTest.kt
@@ -692,7 +692,7 @@ class WorkspaceServiceIntegrationTest : CsmRedisTestBase() {
       SolutionCreateRequest(
           key = UUID.randomUUID().toString(),
           name = "My solution",
-          runTemplates = mutableListOf(RunTemplate("template")),
+          runTemplates = mutableListOf(RunTemplateCreateRequest("template")),
           parameters = mutableListOf(RunTemplateParameterCreateRequest("parameter", "string")),
           csmSimulator = "simulator",
           parameterGroups = mutableListOf(RunTemplateParameterGroupCreateRequest("group")),

--- a/workspace/src/integrationTest/kotlin/com/cosmotech/workspace/service/WorkspaceServiceRBACTest.kt
+++ b/workspace/src/integrationTest/kotlin/com/cosmotech/workspace/service/WorkspaceServiceRBACTest.kt
@@ -1696,7 +1696,7 @@ class WorkspaceServiceRBACTest : CsmRedisTestBase() {
           version = "1.0.0",
           repository = "repository",
           parameterGroups = mutableListOf(RunTemplateParameterGroupCreateRequest("group")),
-          runTemplates = mutableListOf(RunTemplate("template")),
+          runTemplates = mutableListOf(RunTemplateCreateRequest("template")),
           security =
               SolutionSecurity(
                   default = ROLE_NONE,

--- a/workspace/src/test/kotlin/com/cosmotech/workspace/service/WorkspaceServiceImplTests.kt
+++ b/workspace/src/test/kotlin/com/cosmotech/workspace/service/WorkspaceServiceImplTests.kt
@@ -661,7 +661,8 @@ class WorkspaceServiceImplTests {
             mutableListOf(
                 RunTemplateParameterGroup(
                     id = "group", isTable = false, parameters = mutableListOf())),
-        runTemplates = mutableListOf(RunTemplate("template")),
+        runTemplates =
+            mutableListOf(RunTemplate(id = "template", parameterGroups = mutableListOf())),
         security =
             SolutionSecurity(
                 ROLE_ADMIN, mutableListOf(SolutionAccessControl(CONNECTED_ADMIN_USER, ROLE_ADMIN))))


### PR DESCRIPTION
### Important:

You can now update solution runTemplates via solution update endpoint (/organizations/{organization_id}/solutions/{solution_id}.
Now, If no run Template is specified when a solution update is requested, solution will have empty runTemplates property after update.

### Additional endpoints:
As we allowed runTemplates property to be updated when a solution is updated, we added CRUD endpoints for solution runTemplates to manage this property easily:

- GET /organizations/{organization_id}/solutions/{solution_id}/runTemplates
- POST /organizations/{organization_id}/solutions/{solution_id}/runTemplates
- GET /organizations/{organization_id}/solutions/{solution_id}/runTemplates/{parameter_group_id}
- PATCH /organizations/{organization_id}/solutions/{solution_id}/runTemplates/{parameter_group_id}
- DELETE /organizations/{organization_id}/solutions/{solution_id}/runTemplates/{parameter_group_id}