### PR TITLE
Fix updateSolution with empty SolutionUpdateRequest

### DIFF
--- a/doc/Models/SolutionUpdateRequest.md
+++ b/doc/Models/SolutionUpdateRequest.md
@@ -7,7 +7,7 @@
 | **name** | **String** | The Solution name | [optional] [default to null] |
 | **description** | **String** | The Solution description | [optional] [default to null] |
 | **repository** | **String** | The registry repository containing the image | [optional] [default to null] |
-| **alwaysPull** | **Boolean** | Set to true if the runtemplate wants to always pull the image | [optional] [default to false] |
+| **alwaysPull** | **Boolean** | Set to true if the runtemplate wants to always pull the image | [optional] [default to null] |
 | **version** | **String** | The Solution version MAJOR.MINOR.PATCH. Must be aligned with an existing repository tag | [optional] [default to null] |
 | **url** | **String** | An optional URL link to solution page | [optional] [default to null] |
 | **tags** | **List** | The list of tags | [optional] [default to null] |

--- a/solution/src/integrationTest/kotlin/com/cosmotech/solution/service/SolutionServiceIntegrationTest.kt
+++ b/solution/src/integrationTest/kotlin/com/cosmotech/solution/service/SolutionServiceIntegrationTest.kt
@@ -148,6 +148,49 @@ class SolutionServiceIntegrationTest : CsmRedisTestBase() {
     assertTrue(solutionsFoundAfterDelete.size == 1)
   }
 
+  @Test
+  fun `test update solution with empty SolutionUpdateRequest`() {
+
+    val solutionKey = "key"
+    val solutionName = "name"
+    val solutionDescription = "description"
+    val solutionVersion = "1.0.0"
+    val solutionTags = mutableListOf("tag1", "tag2")
+    val solutionUrl = "url"
+    val solutionRunTemplates = mutableListOf(RunTemplateCreateRequest(id = "template"))
+    val solutionParameterGroups =
+        mutableListOf(RunTemplateParameterGroupCreateRequest(id = "group"))
+    val solutionRepository = "repository"
+
+    val solutionCreateRequest =
+        SolutionCreateRequest(
+            key = solutionKey,
+            name = solutionName,
+            description = solutionDescription,
+            version = solutionVersion,
+            tags = solutionTags,
+            repository = solutionRepository,
+            runTemplates = solutionRunTemplates,
+            parameterGroups = solutionParameterGroups,
+            parameters =
+                mutableListOf(
+                    RunTemplateParameterCreateRequest(id = "parameterName", varType = "string")),
+            security =
+                SolutionSecurity(
+                    default = ROLE_ADMIN,
+                    accessControlList =
+                        mutableListOf(SolutionAccessControl("user_id", ROLE_ADMIN))),
+            url = solutionUrl,
+            alwaysPull = true,
+        )
+    val newSolution = solutionApiService.createSolution(organizationSaved.id, solutionCreateRequest)
+
+    val solutionUpdated =
+        solutionApiService.updateSolution(
+            organizationSaved.id, newSolution.id, SolutionUpdateRequest())
+    assertEquals(newSolution, solutionUpdated)
+  }
+
   @TestFactory
   fun `sdkVersion on Solution CRUD`() =
       mapOf(
@@ -1019,7 +1062,8 @@ class SolutionServiceIntegrationTest : CsmRedisTestBase() {
             alwaysPull = false,
             repository = updatedRepository,
             url = newUrl,
-            version = newVersion)
+            version = newVersion,
+            parameters = mutableListOf())
 
     solutionSaved =
         solutionApiService.updateSolution(
@@ -1161,7 +1205,10 @@ class SolutionServiceIntegrationTest : CsmRedisTestBase() {
             alwaysPull = false,
             repository = updatedRepository,
             url = newUrl,
-            version = newVersion)
+            version = newVersion,
+            runTemplates = mutableListOf(),
+            parameters = mutableListOf(),
+        )
 
     solutionSaved =
         solutionApiService.updateSolution(

--- a/solution/src/main/kotlin/com/cosmotech/solution/service/SolutionServiceImpl.kt
+++ b/solution/src/main/kotlin/com/cosmotech/solution/service/SolutionServiceImpl.kt
@@ -259,16 +259,16 @@ class SolutionServiceImpl(
 
     val solutionRunTemplateParameters =
         solutionUpdateRequest.parameters?.map { convertToRunTemplateParameter(it) }?.toMutableList()
-            ?: mutableListOf()
+            ?: existingSolution.parameters
 
     val solutionRunTemplateParameterGroups =
         solutionUpdateRequest.parameterGroups
             ?.map { convertToRunTemplateParameterGroup(it) }
-            ?.toMutableList() ?: mutableListOf()
+            ?.toMutableList() ?: existingSolution.parameterGroups
 
     val solutionRunTemplates =
         solutionUpdateRequest.runTemplates?.map { convertToRunTemplate(it) }?.toMutableList()
-            ?: mutableListOf()
+            ?: existingSolution.runTemplates
 
     val updatedSolution =
         Solution(

--- a/solution/src/main/openapi/solution.yaml
+++ b/solution/src/main/openapi/solution.yaml
@@ -1101,7 +1101,6 @@ components:
         alwaysPull:
           type: boolean
           description: Set to true if the runtemplate wants to always pull the image
-          default: false
         version:
           type: string
           description: The Solution version MAJOR.MINOR.PATCH. Must be aligned with an existing repository tag


### PR DESCRIPTION
- Remove default property alwaysPull in SolutionUpdateRequest
- fix update mechanism for runTemplates/parameters/parameterGroups on updateSolution