### PR TITLE
Fix "Could not resolve org.jetbrains.kotlin:kotlin-test:1.9.23"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 // See https://docs.gradle.org/current/userguide/organizing_gradle_projects.html#sec:build_sources
 
 plugins {
-  val kotlinVersion = "1.9.23"
+  val kotlinVersion = "1.9.25"
   kotlin("jvm") version kotlinVersion
   kotlin("plugin.spring") version kotlinVersion apply false
   id("pl.allegro.tech.build.axion-release") version "1.15.5"


### PR DESCRIPTION
At this point, I don't know why we get this error. Everything looks great and accessible in mvnrepository especially kotlin library. But we do have the following error:
```
Could not resolve org.jetbrains.kotlin:kotlin-test:1.9.23.
     Required by:
         project :cosmotech-connector-api
      > Unable to find a variant of org.jetbrains.kotlin:kotlin-test:1.9.23 providing the requested capability org.jetbrains.kotlin:kotlin-test-framework-junit5:
```
Upgrading kotlin version to 1.9.25 will force the kotlin-test module's version to 1.9.25 too and it apparently fixes the compilation error message...