### PR TITLE
fix: do not trigger on branches as we still only have one project

### DIFF
--- a/.github/workflows/track_dependencies.yml
+++ b/.github/workflows/track_dependencies.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - 'release/**'
 
 jobs:
   dependency_track:


### PR DESCRIPTION
We haven't yet implemented correctly the tracking of other releases, so to avoid overwriting the existing ones we need to drop the triggering on other branches