### PR TITLE
Remove vendor and identity provider code properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,6 @@ You can run the application via the `bootRun` Gradle task, like so:
 Once the application is started, you can head to the Swagger UI exposed at http://localhost:8080 to
 navigate through the API.
 
-If you use another Identity Provider like Okta, you must set the gradle property IdentityProvider:
-```shell
-./gradlew :cosmotech-api:bootRun -PidentityProvider=okta
-```
-
 If you need to call endpoints that require access to a kubernetes cluster, it will use the current context from your kubernetes local config file.
 If you want to use a different context/cluster without changing your default settings, you may pass the `useKubernetesContext` property to the JVM:
 ```shell

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -529,11 +529,6 @@ subprojects {
   tasks.getByName<BootRun>("bootRun") {
     workingDir = rootDir
 
-    environment("CSM_PLATFORM_VENDOR", project.findProperty("platform")?.toString() ?: "")
-    project.findProperty("identityProvider")?.toString()?.let {
-      environment("IDENTITY_PROVIDER", it)
-    }
-
     if (project.hasProperty("jvmArgs")) {
       jvmArgs = project.property("jvmArgs").toString().split("\\s+".toRegex()).toList()
     }

--- a/common/src/main/kotlin/com/cosmotech/common/config/CsmApiConfiguration.kt
+++ b/common/src/main/kotlin/com/cosmotech/common/config/CsmApiConfiguration.kt
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 package com.cosmotech.common.config
 
-import com.cosmotech.common.config.CsmPlatformProperties.Vendor.ON_PREMISE
 import com.cosmotech.common.utils.yamlObjectMapper
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
@@ -50,13 +49,10 @@ open class CsmPlatformEnvironmentPostProcessor : EnvironmentPostProcessor {
       environment: ConfigurableEnvironment,
       application: SpringApplication
   ) {
-    val platform = (System.getenv("CSM_PLATFORM_VENDOR") ?: ON_PREMISE.toString()).lowercase()
-    addSpringProfile(platform, environment)
-    val identityProvider = (System.getenv("IDENTITY_PROVIDER") ?: "keycloak")
-    addSpringProfile(identityProvider, environment)
+    addSpringProfile(environment)
   }
 
-  private fun addSpringProfile(profile: String, environment: ConfigurableEnvironment) {
+  private fun addSpringProfile(environment: ConfigurableEnvironment, profile: String = "keycloak") {
     if (profile.isNotBlank()) {
       if (environment.activeProfiles.none { profile.equals(it, ignoreCase = true) }) {
         log.debug("Adding '$profile' as an active profile")

--- a/common/src/main/kotlin/com/cosmotech/common/config/CsmPlatformProperties.kt
+++ b/common/src/main/kotlin/com/cosmotech/common/config/CsmPlatformProperties.kt
@@ -12,9 +12,6 @@ data class CsmPlatformProperties(
     /** API Configuration */
     val api: Api,
 
-    /** Platform vendor */
-    val vendor: Vendor = Vendor.ON_PREMISE,
-
     /** Id Generator */
     val idGenerator: IdGenerator,
 
@@ -33,10 +30,7 @@ data class CsmPlatformProperties(
     /** Authorization Configuration */
     val authorization: Authorization = Authorization(),
 
-    /**
-     * Identity provider used for (Entra ID ,Okta, Keycloak) if openapi default configuration needs
-     * to be overwritten
-     */
+    /** Identity provider used if openapi default configuration needs to be overwritten */
     val identityProvider: CsmIdentityProvider,
 
     /** Twin Data Layer configuration */
@@ -296,33 +290,14 @@ data class CsmPlatformProperties(
       val password: String? = null,
   )
 
-  enum class Vendor {
-    /** Microsoft Azure : https://azure.microsoft.com/en-us/ */
-    AZURE,
-    ON_PREMISE
-  }
-
   data class CsmIdentityProvider(
-      /** okta|azure|keycloak */
-      val code: String,
-
-      /**
-       * entry sample :
-       * - {"http://dev.api.cosmotech.com/platform" to "Platform scope"}
-       * - {"default" to "Default scope"}
-       */
+      /** Scopes */
       val defaultScopes: Map<String, String> = emptyMap(),
 
-      /**
-       * - "https://{yourOktaDomain}/oauth2/default/v1/authorize"
-       * - "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
-       */
+      /** Authorization URL */
       val authorizationUrl: String,
 
-      /**
-       * - "https://{yourOktaDomain}/oauth2/default/v1/token"
-       * - "https://login.microsoftonline.com/common/oauth2/v2.0/token"
-       */
+      /** Token URL */
       val tokenUrl: String,
 
       /**

--- a/common/src/test/kotlin/com/cosmotech/common/rbac/CsmRbacTests.kt
+++ b/common/src/test/kotlin/com/cosmotech/common/rbac/CsmRbacTests.kt
@@ -80,7 +80,6 @@ class CsmRbacTests {
 
   private val DEFAULT_IDENTITY_PROVIDER =
       CsmPlatformProperties.CsmIdentityProvider(
-          "identityProviderCode",
           authorizationUrl = "http://my-fake-authorization.url/autorize",
           tokenUrl = "http://my-fake-token.url/token",
           adminGroup = CUSTOM_ADMIN_GROUP,

--- a/run/src/main/kotlin/com/cosmotech/run/RunContainerFactory.kt
+++ b/run/src/main/kotlin/com/cosmotech/run/RunContainerFactory.kt
@@ -330,7 +330,6 @@ internal fun getMinimalCommonEnvVars(
   val containerScopes = getContainerScopes(csmPlatformProperties)
   val commonEnvVars =
       mapOf(
-          IDENTITY_PROVIDER to (csmPlatformProperties.identityProvider.code),
           IDP_TENANT_ID to csmPlatformProperties.identityProvider.identity.tenantId,
           IDP_CLIENT_ID to csmPlatformProperties.identityProvider.identity.clientId,
           IDP_CLIENT_SECRET to csmPlatformProperties.identityProvider.identity.clientSecret,

--- a/run/src/test/kotlin/com/cosmotech/run/ContainerFactoryTests.kt
+++ b/run/src/test/kotlin/com/cosmotech/run/ContainerFactoryTests.kt
@@ -77,7 +77,6 @@ class ContainerFactoryTests {
         )
     every { csmPlatformProperties.identityProvider } returns
         CsmPlatformProperties.CsmIdentityProvider(
-            code = "keycloak",
             defaultScopes = mapOf("This is a fake scope id" to "This is a fake scope name"),
             authorizationUrl = "http://this_is_a_fake_url.com",
             tokenUrl = "http://this_is_a_fake_token_url.com",
@@ -185,7 +184,6 @@ class ContainerFactoryTests {
         image = "twinengines.azurecr.io/" + solution.repository + ":" + solution.version,
         envVars =
             mapOf(
-                "IDENTITY_PROVIDER" to "keycloak",
                 "CSM_API_SCOPE" to "/.default",
                 "CSM_API_URL" to csmPlatformProperties.api.baseUrl,
                 "CSM_DATASET_ABSOLUTE_PATH" to "/mnt/scenariorun-data",


### PR DESCRIPTION
- Eliminated `vendor` from `CsmPlatformProperties` and related configurations.
- Removed `identityProvider.code` from platform properties and associated usages in tests, configs, and runtime environments.
- Refactored environment profiles.